### PR TITLE
Fix Next.js compile errors

### DIFF
--- a/pages/patients/clark.tsx
+++ b/pages/patients/clark.tsx
@@ -1,7 +1,7 @@
 // pages/patients/clark.tsx
 'use client'
 import React, { useEffect, useState } from 'react'
-import { Grid } from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
   Box,
@@ -185,22 +185,22 @@ export default function ClarkPatientPage() {
 
           {/* Demographics */}
           <Grid container spacing={2} sx={{ mb: 3 }}>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">DOB</Typography>
               <Typography>{patient.dob}</Typography>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">MRN</Typography>
               <Typography>{patient.mrn}</Typography>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">Referral Date</Typography>
               <Box sx={{ display: 'flex', alignItems: 'center' }}>
                 <Typography>{patient.referralDate}</Typography>
                 <PdfIcons files={pdfMap.referral} />
               </Box>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">Contact</Typography>
               <Typography>{patient.contact}</Typography>
             </Grid>
@@ -251,7 +251,7 @@ export default function ClarkPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.tteData).map(([k, v]) => (
-                  <Grid item xs={6} key={k}>
+                  <Grid xs={6} key={k}>
                     <Typography variant="body2">
                       <strong>{k}:</strong> {v}
                     </Typography>
@@ -299,7 +299,7 @@ export default function ClarkPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.bloods).map(([k, v]) => (
-                  <Grid item xs={6} key={k}>
+                  <Grid xs={6} key={k}>
                     <Typography variant="body2">
                       <strong>{k}:</strong> {v}
                     </Typography>
@@ -318,7 +318,7 @@ export default function ClarkPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.otherConsults).map(([k, v]) => (
-                  <Grid item xs={6} key={k}>
+                  <Grid xs={6} key={k}>
                     <Typography variant="body2">
                       <strong>{k}:</strong> {v || '—'}
                     </Typography>

--- a/pages/patients/english.tsx
+++ b/pages/patients/english.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
-import { Grid } from '@mui/material';
+import Grid from '@mui/material/GridLegacy';
 import { useRouter } from 'next/router'
 import {
   Box,
@@ -166,7 +166,7 @@ export default function EnglishPatientPage() {
           {/* Demographics */}
           <Grid container spacing={2} sx={{ mb: 3 }}>
             {['dob', 'mrn', 'referralDate', 'email'].map((field) => (
-              <Grid item xs={6} sm={3} key={field}>
+              <Grid xs={6} sm={3} key={field}>
                 <Typography variant="subtitle2">{field.charAt(0).toUpperCase() + field.slice(1)}</Typography>
                 <Typography>{(patient as any)[field]}</Typography>
               </Grid>
@@ -211,7 +211,7 @@ export default function EnglishPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.tteData).map(([k, v]) => (
-                  <Grid item xs={6} key={k}>
+                  <Grid xs={6} key={k}>
                     <Typography variant="body2"><strong>{k}:</strong> {v}</Typography>
                   </Grid>
                 ))}
@@ -251,7 +251,7 @@ export default function EnglishPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.bloods).map(([k, v]) => (
-                  <Grid item xs={6} key={k}>
+                  <Grid xs={6} key={k}>
                     <Typography variant="body2"><strong>{k}:</strong> {v}</Typography>
                   </Grid>
                 ))}
@@ -268,7 +268,7 @@ export default function EnglishPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.otherConsults).map(([k, v]) => (
-                  <Grid item xs={6} key={k}>
+                  <Grid xs={6} key={k}>
                     <Typography variant="body2"><strong>{k}:</strong> {v}</Typography>
                   </Grid>
                 ))}

--- a/pages/patients/gaffney.tsx
+++ b/pages/patients/gaffney.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -12,7 +13,6 @@ import {
     Tooltip,
     TextField,
     Divider,
-    Grid
 } from '@mui/material'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import { getAge } from '../../data/patients'
@@ -209,19 +209,19 @@ export default function GaffneyPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referrer</Typography>
                             <Typography>{patient.referrer}</Typography>
                         </Grid>
@@ -271,7 +271,7 @@ export default function GaffneyPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -301,7 +301,7 @@ export default function GaffneyPatientPage() {
                             <Typography sx={sectionTitleSx}>Bloods</Typography>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/grasso.tsx
+++ b/pages/patients/grasso.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-// import { Grid } from '@mui/material';
+import Grid from '@mui/material/GridLegacy'
 import {
   Box,
   Paper,
@@ -7,7 +7,6 @@ import {
   CardHeader,
   CardContent,
   Typography,
-  Grid,
   Tooltip,
   IconButton,
   TextField,
@@ -106,35 +105,35 @@ export default function GrassoPatientPage() {
         Patient Details
       </Typography>
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">DOB</Typography>
           <Typography>19/12/1938</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Age</Typography>
           <Typography>86</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">MRN</Typography>
           <Typography>0274378</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referral Date</Typography>
           <Typography>30/5/25</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Structural Physician</Typography>
           <Typography>Dr Bhindi</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referrer</Typography>
           <Typography>Dr Bassin / Dr Rogers</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Contact</Typography>
           <Typography>0400 233 289</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Email/Alt Contact</Typography>
           <Typography>Grace 0408 478 007</Typography>
         </Grid>
@@ -145,7 +144,7 @@ export default function GrassoPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Background</Typography>} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Past Medical History:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Atrial fibrillation</li>
@@ -159,7 +158,7 @@ export default function GrassoPatientPage() {
                 <li>Bakers cyst</li>
               </Box>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Medications:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Amitriptyline 10mg</li>

--- a/pages/patients/green.tsx
+++ b/pages/patients/green.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-// import { Grid } from '@mui/material';
+import Grid from '@mui/material/GridLegacy'
 import {
   Box,
   Paper,
@@ -7,7 +7,6 @@ import {
   CardHeader,
   CardContent,
   Typography,
-  Grid,
   Tooltip,
   IconButton,
   TextField,
@@ -108,27 +107,27 @@ export default function GreenPatientPage() {
         Patient Details
       </Typography>
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">DOB</Typography>
           <Typography>27/10/1946</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Age</Typography>
           <Typography>78</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">MRN</Typography>
           <Typography>0198323</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Height/Weight</Typography>
           <Typography>1.82m / 97kg</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Structural Physician</Typography>
           <Typography>Dr Hansen</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referrer</Typography>
           <Typography>Dr Vernon</Typography>
         </Grid>
@@ -139,7 +138,7 @@ export default function GreenPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Background</Typography>} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Past Medical History:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Perimount 25mm Tissue AVR + LAA closure (2018)</li>
@@ -158,7 +157,7 @@ export default function GreenPatientPage() {
                 <li>ORIF fractured hip</li>
               </Box>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Medications:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Tranexamic Acid 1g tds</li>

--- a/pages/patients/index.tsx
+++ b/pages/patients/index.tsx
@@ -7,7 +7,6 @@ import {
     Container,
     Box,
     Typography,
-    Grid,
     Paper,
     Button,
 } from '@mui/material'

--- a/pages/patients/kniepp.tsx
+++ b/pages/patients/kniepp.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-// import { Grid } from '@mui/material';
+import Grid from '@mui/material/GridLegacy'
 import {
   Box,
   Paper,
@@ -7,7 +7,6 @@ import {
   CardHeader,
   CardContent,
   Typography,
-  Grid,
   Tooltip,
   IconButton,
   TextField,
@@ -104,39 +103,39 @@ export default function KnieppPatientPage() {
         Patient Details
       </Typography>
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">DOB</Typography>
           <Typography>7/12/1950</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Age</Typography>
           <Typography>74</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">MRN</Typography>
           <Typography>2029741</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referral Date</Typography>
           <Typography>12/6/25</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Structural Physician</Typography>
           <Typography>Dr Hansen</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referrer</Typography>
           <Typography>Dr Chung (Renal)</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Contact</Typography>
           <Typography>9346 1300</Typography>
         </Grid>
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <Typography variant="subtitle2" color="textSecondary">Weight/Height</Typography>
           <Typography>65kg / 160cm</Typography>
         </Grid>
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <Typography variant="subtitle2" color="textSecondary">Comments</Typography>
           <Typography>Intellectual disability; public Guardian</Typography>
         </Grid>
@@ -147,7 +146,7 @@ export default function KnieppPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Background</Typography>} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Past Medical History:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Intellectual disability (public guardianship)</li>
@@ -155,7 +154,7 @@ export default function KnieppPatientPage() {
                 <li>Schizoaffective disorder</li>
               </Box>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Medications:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Calcitriol 0.25mcg</li>
@@ -195,13 +194,13 @@ export default function KnieppPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>TTE: 12/6/25</Typography>} action={<PdfIcons files={pdfMap.tte} />} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">LV EF</Typography><Typography>55-60%</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">AVA</Typography><Typography>0.9</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">AVAi</Typography><Typography>0.5</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Peak Gradient</Typography><Typography>80.6</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Mean Gradient</Typography><Typography>47</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Peak AV</Typography><Typography>4.5</Typography></Grid>
-            <Grid item xs={12}><Typography variant="subtitle2" color="textSecondary">Comments</Typography><Typography>Severe AS, trileaflet valve; echo density in LA</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">LV EF</Typography><Typography>55-60%</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">AVA</Typography><Typography>0.9</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">AVAi</Typography><Typography>0.5</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Peak Gradient</Typography><Typography>80.6</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Mean Gradient</Typography><Typography>47</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Peak AV</Typography><Typography>4.5</Typography></Grid>
+            <Grid xs={12}><Typography variant="subtitle2" color="textSecondary">Comments</Typography><Typography>Severe AS, trileaflet valve; echo density in LA</Typography></Grid>
           </Grid>
         </CardContent>
       </Card>
@@ -247,11 +246,11 @@ export default function KnieppPatientPage() {
         />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography variant="subtitle2" color="textSecondary">Cardiothoracic Surgeon</Typography>
               <Typography>Dr Sherrah</Typography>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography variant="subtitle2" color="textSecondary">Structural Consult</Typography>
               <Typography>&nbsp;</Typography>
             </Grid>

--- a/pages/patients/lingard.tsx
+++ b/pages/patients/lingard.tsx
@@ -1,6 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
-import { Grid } from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -163,19 +163,19 @@ export default function LingardPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referral Date</Typography>
                             <Typography>{patient.referralDate}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
@@ -223,7 +223,7 @@ export default function LingardPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -271,7 +271,7 @@ export default function LingardPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -290,7 +290,7 @@ export default function LingardPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.otherConsults).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v || '—'}
                                         </Typography>

--- a/pages/patients/mcguire.tsx
+++ b/pages/patients/mcguire.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -12,7 +13,6 @@ import {
     Tooltip,
     TextField,
     Divider,
-    Grid
 } from '@mui/material'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import { getAge } from '../../data/patients'
@@ -198,22 +198,22 @@ export default function McGuirePatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referral Date</Typography>
                             <Box sx={{ display: 'flex', alignItems: 'center' }}>
                                 <Typography>{patient.referralDate || '—'}</Typography>
                                 <PdfIcons files={pdfMap.referral} />
                             </Box>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
@@ -264,7 +264,7 @@ export default function McGuirePatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -323,7 +323,7 @@ export default function McGuirePatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -344,7 +344,7 @@ export default function McGuirePatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.otherConsults).map(([k, v]) => (
-                                    <Grid item xs={12} key={k}>
+                                    <Grid xs={12} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/mcmullen.tsx
+++ b/pages/patients/mcmullen.tsx
@@ -1,7 +1,7 @@
 // pages/patients/mcmullen.tsx
 'use client'
 import React, { useEffect, useState } from 'react'
-import { Grid } from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -173,22 +173,22 @@ export default function McmullenPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referral Date</Typography>
                             <Box sx={{ display: 'flex', alignItems: 'center' }}>
                                 <Typography>{patient.referralDate}</Typography>
                                 <PdfIcons files={pdfMap.referral} />
                             </Box>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
@@ -239,7 +239,7 @@ export default function McmullenPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -287,7 +287,7 @@ export default function McmullenPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/mooney.tsx
+++ b/pages/patients/mooney.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -12,7 +13,6 @@ import {
     Tooltip,
     TextField,
     Divider,
-    Grid
 } from '@mui/material'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import { getAge } from '../../data/patients'
@@ -197,19 +197,19 @@ export default function MooneyPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referrer</Typography>
                             <Typography>{patient.referrer}</Typography>
                         </Grid>
@@ -259,7 +259,7 @@ export default function MooneyPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -289,7 +289,7 @@ export default function MooneyPatientPage() {
                             <Typography sx={sectionTitleSx}>Bloods</Typography>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/nas.tsx
+++ b/pages/patients/nas.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -12,7 +13,6 @@ import {
     Tooltip,
     TextField,
     Divider,
-    Grid
 } from '@mui/material'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import { getAge } from '../../data/patients'
@@ -207,19 +207,19 @@ export default function NasPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>ME00463006</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referrer</Typography>
                             <Typography>{patient.referrer}</Typography>
                         </Grid>
@@ -285,7 +285,7 @@ export default function NasPatientPage() {
                             <Typography sx={sectionTitleSx}>Recent Bloods</Typography>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/newlands.tsx
+++ b/pages/patients/newlands.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -12,8 +13,7 @@ import {
     Tooltip,
     TextField,
     Divider,
-    Grid,
-} from '@mui/material'
+    } from '@mui/material'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import { getAge } from '../../data/patients'
 
@@ -208,19 +208,19 @@ export default function NewlandsPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referral Date</Typography>
                             <Typography>{patient.referralDate}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
@@ -270,7 +270,7 @@ export default function NewlandsPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -318,7 +318,7 @@ export default function NewlandsPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/pavlidis.tsx
+++ b/pages/patients/pavlidis.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-// import { Grid } from '@mui/material';
+import Grid from '@mui/material/GridLegacy'
 import {
   Box,
   Paper,
@@ -7,7 +7,6 @@ import {
   CardHeader,
   CardContent,
   Typography,
-  Grid,
   Tooltip,
   IconButton,
   TextField,
@@ -116,55 +115,55 @@ export default function PavlidisPatientPage() {
 
       {/* Patient Details Grid */}
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">
             DOB
           </Typography>
           <Typography>23/1/1951</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">
             Age
           </Typography>
           <Typography>74</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">
             MRN
           </Typography>
           <Typography>0791463</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">
             Referral Date
           </Typography>
           <Typography>23/5/25</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">
             Structural Physician
           </Typography>
           <Typography>Dr Bhindi</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">
             Referrer
           </Typography>
           <Typography>Dr Yeoh / Dr Ekmijian</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">
             Contact
           </Typography>
           <Typography>Louise (wife): 0415 100 153</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">
             Email
           </Typography>
           <Typography>&nbsp;</Typography>
         </Grid>
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <Typography variant="subtitle2" color="textSecondary">
             Special Comments
           </Typography>
@@ -179,7 +178,7 @@ export default function PavlidisPatientPage() {
         />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>
                 Past Medical History:
               </Typography>
@@ -195,7 +194,7 @@ export default function PavlidisPatientPage() {
                 <li>OSA</li>
               </Box>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>
                 Medications:
               </Typography>

--- a/pages/patients/riggs.tsx
+++ b/pages/patients/riggs.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import Grid from '@mui/material/GridLegacy'
 import {
   Box,
   Paper,
@@ -6,7 +7,6 @@ import {
   CardHeader,
   CardContent,
   Typography,
-  Grid,
   Tooltip,
   IconButton,
   TextField,
@@ -104,38 +104,38 @@ export default function RiggsPatientPage() {
         Patient Details
       </Typography>
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">DOB</Typography>
           <Typography>14/07/1945</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Age</Typography>
           <Typography>79</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">MRN</Typography>
           <Typography>0346148</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referral Date</Typography>
           <Box display="flex" alignItems="center">
             <Typography>15/6/25</Typography>
             <PdfIcons files={pdfMap.referral} />
           </Box>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Structural Physician</Typography>
           <Typography>Dr Hansen</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referrer</Typography>
           <Typography>Dr Hill</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Contact</Typography>
           <Typography>0417 883 916</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Weight</Typography>
           <Typography>96 kg</Typography>
         </Grid>
@@ -146,7 +146,7 @@ export default function RiggsPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Background</Typography>} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Background:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>IHD</li>
@@ -159,7 +159,7 @@ export default function RiggsPatientPage() {
                 <li>Rheumatoid arthritis</li>
               </Box>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Medications:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Apixaban 5mg bd</li>
@@ -196,15 +196,15 @@ export default function RiggsPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>TTE 20/6/25</Typography>} action={<PdfIcons files={pdfMap.tte} />} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">LV EF</Typography><Typography>30%</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">AVA</Typography><Typography>0.8</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">AVAi</Typography><Typography>0.4</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Peak Gradient</Typography><Typography>54</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Mean Gradient</Typography><Typography>33</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">SVI</Typography><Typography>38.2</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Peak AV</Typography><Typography>3.7</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">MR</Typography><Typography>Mild</Typography></Grid>
-            <Grid item xs={12}><Typography variant="subtitle2" color="textSecondary">Comments</Typography><Typography>Bioprosthetic aortic valve in situ. Turbulent flow and increased velocities through prosthesis (moderate-severe stenosis).</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">LV EF</Typography><Typography>30%</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">AVA</Typography><Typography>0.8</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">AVAi</Typography><Typography>0.4</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Peak Gradient</Typography><Typography>54</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Mean Gradient</Typography><Typography>33</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">SVI</Typography><Typography>38.2</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Peak AV</Typography><Typography>3.7</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">MR</Typography><Typography>Mild</Typography></Grid>
+            <Grid xs={12}><Typography variant="subtitle2" color="textSecondary">Comments</Typography><Typography>Bioprosthetic aortic valve in situ. Turbulent flow and increased velocities through prosthesis (moderate-severe stenosis).</Typography></Grid>
           </Grid>
         </CardContent>
       </Card>
@@ -222,8 +222,8 @@ export default function RiggsPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Angio & ECG</Typography>} action={<PdfIcons files={pdfMap.angio} />} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={12}><Typography variant="subtitle2" color="textSecondary">Angio</Typography><Typography>Mild coronary artery disease</Typography></Grid>
-            <Grid item xs={12}><Typography variant="subtitle2" color="textSecondary">ECG</Typography><Typography>Sinus rhythm 38–92, avg 65 bpm, LBBB pattern</Typography></Grid>
+            <Grid xs={12}><Typography variant="subtitle2" color="textSecondary">Angio</Typography><Typography>Mild coronary artery disease</Typography></Grid>
+            <Grid xs={12}><Typography variant="subtitle2" color="textSecondary">ECG</Typography><Typography>Sinus rhythm 38–92, avg 65 bpm, LBBB pattern</Typography></Grid>
           </Grid>
         </CardContent>
       </Card>
@@ -250,12 +250,12 @@ export default function RiggsPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Bloods 3/6/25</Typography>} action={<PdfIcons files={pdfMap.bloods} />} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={12}><Typography variant="subtitle2" color="textSecondary">MOCA</Typography><Typography>29/30 (with GP)</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Hb</Typography><Typography>145</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Plts</Typography><Typography>189</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Cre</Typography><Typography>85</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">eGFR</Typography><Typography>75</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Albumin</Typography><Typography>38</Typography></Grid>
+            <Grid xs={12}><Typography variant="subtitle2" color="textSecondary">MOCA</Typography><Typography>29/30 (with GP)</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Hb</Typography><Typography>145</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Plts</Typography><Typography>189</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Cre</Typography><Typography>85</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">eGFR</Typography><Typography>75</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Albumin</Typography><Typography>38</Typography></Grid>
           </Grid>
         </CardContent>
       </Card>
@@ -273,8 +273,8 @@ export default function RiggsPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Other Consults</Typography>} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">CTSx</Typography><Typography>Dr Bassin</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Aged Care</Typography><Typography>N/A</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">CTSx</Typography><Typography>Dr Bassin</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Aged Care</Typography><Typography>N/A</Typography></Grid>
           </Grid>
         </CardContent>
       </Card>

--- a/pages/patients/rosee.tsx
+++ b/pages/patients/rosee.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-// import { Grid } from '@mui/material';
+import Grid from '@mui/material/GridLegacy'
 import {
   Box,
   Paper,
@@ -7,7 +7,6 @@ import {
   CardHeader,
   CardContent,
   Typography,
-  Grid,
   Tooltip,
   IconButton,
   TextField,
@@ -102,35 +101,35 @@ export default function RoseePatientPage() {
         Patient Details
       </Typography>
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">DOB</Typography>
           <Typography>03/09/1943</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Age</Typography>
           <Typography>81</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">MRN</Typography>
           <Typography>0268471</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referral Date</Typography>
           <Typography>23/6/25</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Structural Physician</Typography>
           <Typography>Dr Hansen</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referrer</Typography>
           <Typography>Dr Rogers / Dr Bassin</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Contact</Typography>
           <Typography>Dianne 0476 636 512</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Email</Typography>
           <Typography>dro02956@bigpond.net.au</Typography>
         </Grid>
@@ -141,7 +140,7 @@ export default function RoseePatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Background</Typography>} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Past Medical History:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Sensorineural deafness - since birth</li>
@@ -154,7 +153,7 @@ export default function RoseePatientPage() {
                 <li>Falls 2022, 2023</li>
               </Box>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Medications:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Apixaban 5mg BD</li>
@@ -229,11 +228,11 @@ export default function RoseePatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Other Consults</Typography>} action={<PdfIcons files={pdfMap.referral} />} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography variant="subtitle2" color="textSecondary">Aged Care</Typography>
               <Typography>&nbsp;</Typography>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography variant="subtitle2" color="textSecondary">Cardiothoracic</Typography>
               <Typography>&nbsp;</Typography>
             </Grid>

--- a/pages/patients/ross.tsx
+++ b/pages/patients/ross.tsx
@@ -1,7 +1,7 @@
 // pages/patients/ross.tsx
 'use client'
 import React, { useEffect, useState } from 'react'
-import { Grid } from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -184,22 +184,22 @@ export default function RossPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referral Date</Typography>
                             <Box sx={{ display: 'flex', alignItems: 'center' }}>
                                 <Typography>{patient.referralDate}</Typography>
                                 <PdfIcons files={pdfMap.referral} />
                             </Box>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
@@ -250,7 +250,7 @@ export default function RossPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -301,7 +301,7 @@ export default function RossPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -317,7 +317,7 @@ export default function RossPatientPage() {
                             <Typography sx={sectionTitleSx}>Consults</Typography>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.otherConsults).map(([k, v]) => (
-                                    <Grid item xs={12} key={k}>
+                                    <Grid xs={12} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/russ.tsx
+++ b/pages/patients/russ.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -12,7 +13,6 @@ import {
     Tooltip,
     TextField,
     Divider,
-    Grid
 } from '@mui/material'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import { getAge } from '../../data/patients'
@@ -213,19 +213,19 @@ export default function RussPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referrer</Typography>
                             <Typography>{patient.referrer}</Typography>
                         </Grid>
@@ -274,7 +274,7 @@ export default function RussPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -315,7 +315,7 @@ export default function RussPatientPage() {
                             <Typography sx={sectionTitleSx}>Bloods</Typography>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/shepherd.tsx
+++ b/pages/patients/shepherd.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React, { useEffect, useState } from 'react'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
   Box,
@@ -12,7 +13,6 @@ import {
   Tooltip,
   TextField,
   Divider,
-  Grid
 } from '@mui/material'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import { getAge } from '../../data/patients'
@@ -224,19 +224,19 @@ export default function ShepherdPatientPage() {
 
           {/* Demographics */}
           <Grid container spacing={2} sx={{ mb: 3 }}>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">DOB</Typography>
               <Typography>{patient.dob}</Typography>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">MRN</Typography>
               <Typography>{patient.mrn}</Typography>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">Referral Date</Typography>
               <Typography>{patient.referralDate}</Typography>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">Contact</Typography>
               <Typography>{patient.contact}</Typography>
             </Grid>
@@ -288,7 +288,7 @@ export default function ShepherdPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.tteData).map(([k, v]) => (
-                  <Grid item xs={6} key={k}>
+                  <Grid xs={6} key={k}>
                     <Typography variant="body2">
                       <strong>{k}:</strong> {v}
                     </Typography>
@@ -329,7 +329,7 @@ export default function ShepherdPatientPage() {
               <Typography sx={sectionTitleSx}>Bloods</Typography>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.bloods).map(([k, v]) => (
-                  <Grid item xs={6} key={k}>
+                  <Grid xs={6} key={k}>
                     <Typography variant="body2">
                       <strong>{k}:</strong> {v}
                     </Typography>

--- a/pages/patients/smith.tsx
+++ b/pages/patients/smith.tsx
@@ -1,14 +1,13 @@
 'use client'
 import React, { useEffect, useState } from 'react'
-// import { Grid } from '@mui/material';
 import { useRouter } from 'next/router'
+import Grid from '@mui/material/GridLegacy'
 import {
   Box,
   Container,
   Typography,
   Card,
   CardContent,
-  Grid,
   Stack,
   IconButton,
   Tooltip,
@@ -187,7 +186,7 @@ export default function SmithPatientPage() {
               ['MRN', patient.mrn],
               ['Referral Date', patient.referralDate],
             ].map(([label, value]) => (
-              <Grid item xs={6} sm={3} key={label as string}>
+              <Grid xs={6} sm={3} key={label as string}>
                 <Typography variant="subtitle2">{label}</Typography>
                 <Box sx={{ display: 'flex', alignItems: 'center' }}>
                   <Typography>{value}</Typography>
@@ -195,19 +194,19 @@ export default function SmithPatientPage() {
                 </Box>
               </Grid>
             ))}
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">Structural Physician</Typography>
               <Typography>{patient.structuralPhysician}</Typography>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">Referrer</Typography>
               <Typography>{patient.referrer}</Typography>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">Contact</Typography>
               <Typography>{patient.contact}</Typography>
             </Grid>
-            <Grid item xs={6} sm={3}>
+            <Grid xs={6} sm={3}>
               <Typography variant="subtitle2">Email/Alt Contact</Typography>
               <Typography>{patient.email}</Typography>
             </Grid>
@@ -251,7 +250,7 @@ export default function SmithPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.tteData).map(([label, value]) => (
-                  <Grid item xs={6} key={label}>
+                  <Grid xs={6} key={label}>
                     <Typography variant="body2"><strong>{label}:</strong> {value}</Typography>
                   </Grid>
                 ))}
@@ -291,7 +290,7 @@ export default function SmithPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.bloods).map(([label, value]) => (
-                  <Grid item xs={6} key={label}>
+                  <Grid xs={6} key={label}>
                     <Typography variant="body2"><strong>{label}:</strong> {value}</Typography>
                   </Grid>
                 ))}
@@ -308,7 +307,7 @@ export default function SmithPatientPage() {
               </Box>
               <Grid container spacing={1} sx={{ mt: 1 }}>
                 {Object.entries(patient.otherConsults).map(([label, value]) => (
-                  <Grid item xs={6} key={label}>
+                  <Grid xs={6} key={label}>
                     <Typography variant="body2"><strong>{label}:</strong> {value}</Typography>
                   </Grid>
                 ))}

--- a/pages/patients/smithm.tsx
+++ b/pages/patients/smithm.tsx
@@ -1,7 +1,7 @@
 // pages/patients/smithm.tsx
 'use client'
 import React, { useEffect, useState } from 'react'
-import { Grid } from '@mui/material'
+import Grid from '@mui/material/GridLegacy'
 import { useRouter } from 'next/router'
 import {
     Box,
@@ -192,22 +192,22 @@ export default function SmithMPatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referral Date</Typography>
                             <Box sx={{ display: 'flex', alignItems: 'center' }}>
                                 <Typography>{patient.referralDate || '—'}</Typography>
                                 <PdfIcons files={pdfMap.referral} />
                             </Box>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
@@ -258,7 +258,7 @@ export default function SmithMPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -309,7 +309,7 @@ export default function SmithMPatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -325,7 +325,7 @@ export default function SmithMPatientPage() {
                             <Typography sx={sectionTitleSx}>Consults</Typography>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.otherConsults).map(([k, v]) => (
-                                    <Grid item xs={12} key={k}>
+                                    <Grid xs={12} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/vandevelde.tsx
+++ b/pages/patients/vandevelde.tsx
@@ -1,6 +1,7 @@
 'use client'
 import React, { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
+import Grid from '@mui/material/GridLegacy'
 import {
     Box,
     Container,
@@ -11,8 +12,7 @@ import {
     IconButton,
     Tooltip,
     TextField,
-    Divider,
-    Grid
+    Divider
 } from '@mui/material'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
 import { getAge } from '../../data/patients'
@@ -197,19 +197,19 @@ export default function VandeVeldePatientPage() {
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">DOB</Typography>
                             <Typography>{patient.dob}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">MRN</Typography>
                             <Typography>{patient.mrn}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Contact</Typography>
                             <Typography>{patient.contact}</Typography>
                         </Grid>
-                        <Grid item xs={6} sm={3}>
+                        <Grid xs={6} sm={3}>
                             <Typography variant="subtitle2">Referrer</Typography>
                             <Typography>{patient.referrer}</Typography>
                         </Grid>
@@ -259,7 +259,7 @@ export default function VandeVeldePatientPage() {
                             </Box>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.tteData).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>
@@ -296,7 +296,7 @@ export default function VandeVeldePatientPage() {
                             <Typography sx={sectionTitleSx}>Bloods</Typography>
                             <Grid container spacing={1} sx={{ mt: 1 }}>
                                 {Object.entries(patient.bloods).map(([k, v]) => (
-                                    <Grid item xs={6} key={k}>
+                                    <Grid xs={6} key={k}>
                                         <Typography variant="body2">
                                             <strong>{k}:</strong> {v}
                                         </Typography>

--- a/pages/patients/watson.tsx
+++ b/pages/patients/watson.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-// import { Grid } from '@mui/material';
+import Grid from '@mui/material/GridLegacy';
 import {
   Box,
   Paper,
@@ -7,7 +7,6 @@ import {
   CardHeader,
   CardContent,
   Typography,
-  Grid,
   Tooltip,
   IconButton,
   TextField,
@@ -104,39 +103,39 @@ export default function WatsonPatientPage() {
         Patient Details
       </Typography>
       <Grid container spacing={2} sx={{ mb: 3 }}>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">DOB</Typography>
           <Typography>9/12/1952</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Age</Typography>
           <Typography>72</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">MRN</Typography>
           <Typography>0106881</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referral Date</Typography>
           <Typography>&nbsp;</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Structural Physician</Typography>
           <Typography>Dr Bhindi</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Referrer</Typography>
           <Typography>Dr Rogers</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Contact</Typography>
           <Typography>0412 500 375</Typography>
         </Grid>
-        <Grid item xs={6}>
+        <Grid xs={6}>
           <Typography variant="subtitle2" color="textSecondary">Email</Typography>
           <Typography>sueandbazz@gmail.com</Typography>
         </Grid>
-        <Grid item xs={12}>
+        <Grid xs={12}>
           <Typography variant="subtitle2" color="textSecondary">Weight/Height</Typography>
           <Typography>125kg / 170cm</Typography>
         </Grid>
@@ -147,7 +146,7 @@ export default function WatsonPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Background</Typography>} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Past Medical History:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Severe obesity (125kg, was 140kg)</li>
@@ -161,7 +160,7 @@ export default function WatsonPatientPage() {
                 <li>Osteopaenia</li>
               </Box>
             </Grid>
-            <Grid item xs={6}>
+            <Grid xs={6}>
               <Typography fontWeight={600} gutterBottom>Medications:</Typography>
               <Box component="ul" sx={{ pl: 2, m: 0 }}>
                 <li>Apixaban 5mg</li>
@@ -218,11 +217,11 @@ export default function WatsonPatientPage() {
         />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={12}>
+            <Grid xs={12}>
               <Typography variant="subtitle2" color="textSecondary">Angio</Typography>
               <Typography>Mild non-obstructive CAD</Typography>
             </Grid>
-            <Grid item xs={12}>
+            <Grid xs={12}>
               <Typography variant="subtitle2" color="textSecondary">ECG</Typography>
               <Typography>AF</Typography>
             </Grid>
@@ -235,7 +234,7 @@ export default function WatsonPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>CT TAVI / Access / Valve</Typography>} action={<PdfIcons files={pdfMap.ct} />} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={12}><Typography variant="subtitle2" color="textSecondary">Incidentals</Typography><Typography>The HRCT chest (11/3/25): no evidence of parenchymal dysfunction</Typography></Grid>
+            <Grid xs={12}><Typography variant="subtitle2" color="textSecondary">Incidentals</Typography><Typography>The HRCT chest (11/3/25): no evidence of parenchymal dysfunction</Typography></Grid>
           </Grid>
         </CardContent>
       </Card>
@@ -256,15 +255,15 @@ export default function WatsonPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Bloods (30/4/25)</Typography>} action={<PdfIcons files={pdfMap.bloods} />} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={12}>
+            <Grid xs={12}>
               <Typography variant="subtitle2" color="textSecondary">MOCA / MMSE</Typography>
               <Typography>28/30 <IconButton size="small" sx={{ p: 0 }}>{<PictureAsPdfIcon />}</IconButton></Typography>
             </Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Hb</Typography><Typography>162</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Plts</Typography><Typography>142</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Cre</Typography><Typography>205</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">eGFR</Typography><Typography>27</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Albumin</Typography><Typography>&nbsp;</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Hb</Typography><Typography>162</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Plts</Typography><Typography>142</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Cre</Typography><Typography>205</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">eGFR</Typography><Typography>27</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Albumin</Typography><Typography>&nbsp;</Typography></Grid>
           </Grid>
         </CardContent>
       </Card>
@@ -274,8 +273,8 @@ export default function WatsonPatientPage() {
         <CardHeader title={<Typography sx={sectionTitleSx}>Other Consults</Typography>} action={<PdfIcons files={pdfMap.referral} />} />
         <CardContent>
           <Grid container spacing={2}>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Aged Care</Typography><Typography>&nbsp;</Typography></Grid>
-            <Grid item xs={6}><Typography variant="subtitle2" color="textSecondary">Cardiothoracic Surgeon</Typography><Typography>Dr Bassin</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Aged Care</Typography><Typography>&nbsp;</Typography></Grid>
+            <Grid xs={6}><Typography variant="subtitle2" color="textSecondary">Cardiothoracic Surgeon</Typography><Typography>Dr Bassin</Typography></Grid>
           </Grid>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- switch all patient pages to MUI `GridLegacy`
- remove obsolete `item` prop from patient pages
- drop unused imports

## Testing
- `npm run build`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_687e4e5421308324bd95c0783a7786a4