### PR TITLE
Improve styling

### DIFF
--- a/components/PatientPageClient.tsx
+++ b/components/PatientPageClient.tsx
@@ -5,7 +5,8 @@ import {
   Container,
   Typography,
   Grid,
-  Paper,
+  Card,
+  CardContent,
   Button,
 } from '@mui/material'
 import { allPatients, Patient, getAge } from '../data/patients'
@@ -44,10 +45,11 @@ export default function PatientPageClient() {
   return (
     <Box sx={{ bgcolor: 'background.default', minHeight: '100vh', py: 4 }}>
       <Container maxWidth="sm">
-        <Paper sx={{ p: 3 }}>
-          <Typography variant="h4" gutterBottom>
-            {patient.name}
-          </Typography>
+        <Card elevation={3}>
+          <CardContent>
+            <Typography variant="h4" gutterBottom>
+              {patient.name}
+            </Typography>
           <Grid container spacing={2} sx={{ mb: 2 }}>
             <Grid item xs={6}>
               <Typography variant="subtitle2">DOB</Typography>
@@ -66,10 +68,11 @@ export default function PatientPageClient() {
               <Typography>{patient.consulting}</Typography>
             </Grid>
           </Grid>
-          <Button variant="contained" fullWidth sx={{ mt: 3 }} onClick={complete}>
-            Complete Presentation
-          </Button>
-        </Paper>
+            <Button variant="contained" fullWidth sx={{ mt: 3 }} onClick={complete}>
+              Complete Presentation
+            </Button>
+          </CardContent>
+        </Card>
       </Container>
     </Box>
   )

--- a/components/PatientsClient.tsx
+++ b/components/PatientsClient.tsx
@@ -4,8 +4,11 @@ import {
   Container,
   Box,
   Typography,
-  Paper,
+  Card,
+  CardContent,
   Button,
+  Chip,
+  Stack,
 } from '@mui/material'
 import { allPatients, Patient, getAge } from '../data/patients'
 
@@ -48,47 +51,43 @@ export default function PatientsClient() {
             patients.map((p) => {
               const done = presentedIds.includes(p.id)
               return (
-                <Paper
+                <Card
                   key={p.id}
                   elevation={done ? 1 : 3}
-                  sx={{
-                    p: 3,
-                    display: 'flex',
-                    justifyContent: 'space-between',
-                    alignItems: 'center',
-                    bgcolor: done ? 'grey.50' : 'background.paper',
-                    opacity: done ? 0.6 : 1,
-                    borderRadius: 2,
-                  }}
+                  sx={{ bgcolor: done ? 'grey.50' : 'background.paper', opacity: done ? 0.6 : 1 }}
                 >
-                  <Box>
-                    <Typography variant="h6" component="div">
-                      {p.name}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary">
-                      DOB: {p.dob} &nbsp;|&nbsp; Age: {getAge(p.dob)}
-                    </Typography>
-                    <Box mt={1}>
-                      <Typography variant="body1" component="span" fontWeight={600}>
-                        Referring:
-                      </Typography>{' '}
-                      {p.referring}
-                      <br />
-                      <Typography variant="body1" component="span" fontWeight={600}>
-                        Consulting:
-                      </Typography>{' '}
-                      {p.consulting}
-                    </Box>
-                  </Box>
-                  <Button
-                    variant={done ? 'contained' : 'outlined'}
-                    color={done ? 'success' : 'primary'}
-                    onClick={() => toggle(p.id)}
-                    sx={{ minWidth: 120 }}
-                  >
-                    {done ? 'Presented' : 'Present'}
-                  </Button>
-                </Paper>
+                  <CardContent>
+                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                      <Box>
+                        <Stack direction="row" alignItems="center" spacing={1}>
+                          <Typography variant="h6" component="div">
+                            {p.name}
+                          </Typography>
+                          {p.status === 'private' && (
+                            <Chip label="NSP" color="primary" size="small" />
+                          )}
+                        </Stack>
+                        <Typography variant="body2" color="text.secondary" mt={0.5}>
+                          DOB: {p.dob} &nbsp;|&nbsp; Age: {getAge(p.dob)}
+                        </Typography>
+                        <Typography variant="body2" sx={{ mt: 1 }}>
+                          <strong>Referring:</strong> {p.referring}
+                        </Typography>
+                        <Typography variant="body2">
+                          <strong>Consulting:</strong> {p.consulting}
+                        </Typography>
+                      </Box>
+                      <Button
+                        variant={done ? 'contained' : 'outlined'}
+                        color={done ? 'success' : 'primary'}
+                        onClick={() => toggle(p.id)}
+                        sx={{ minWidth: 120 }}
+                      >
+                        {done ? 'Presented' : 'Present'}
+                      </Button>
+                    </Stack>
+                  </CardContent>
+                </Card>
               )
             })
           )}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,22 @@
+// pages/_app.tsx
+import type { AppProps } from 'next/app'
+import { ThemeProvider, createTheme } from '@mui/material/styles'
+import CssBaseline from '@mui/material/CssBaseline'
+
+const theme = createTheme({
+  palette: {
+    background: {
+      default: '#f5f5f5',
+    },
+  },
+})
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <Component {...pageProps} />
+    </ThemeProvider>
+  )
+}
+

--- a/pages/patients/index.tsx
+++ b/pages/patients/index.tsx
@@ -6,8 +6,11 @@ import {
     Container,
     Box,
     Typography,
-    Paper,
+    Card,
+    CardContent,
     Button,
+    Chip,
+    Stack,
 } from '@mui/material'
 import { allPatients, Patient, getAge } from '../../data/patients'
 
@@ -49,66 +52,43 @@ export default function Patients() {
                     patients.map((patient) => {
                         const isPresented = presentedIds.includes(patient.id)
                         return (
-                            <Paper
+                            <Card
                                 key={patient.id}
                                 elevation={isPresented ? 1 : 3}
-                                sx={{
-                                    p: 3,
-                                    display: 'flex',
-                                    justifyContent: 'space-between',
-                                    alignItems: 'center',
-                                    bgcolor: isPresented ? 'grey.50' : 'background.paper',
-                                    opacity: isPresented ? 0.6 : 1,
-                                    borderRadius: 2,
-                                }}
+                                sx={{ bgcolor: isPresented ? 'grey.50' : 'background.paper', opacity: isPresented ? 0.6 : 1 }}
                             >
-                                <Box>
-                                    <Box display="flex" alignItems="center" gap={1}>
-                                        <Typography variant="h6" component="div">
-                                            {patient.name}
-                                        </Typography>
-                                        {patient.status === 'private' && (
-                                            <Box
-                                                sx={{
-                                                    px: 1.2,
-                                                    py: 0.2,
-                                                    bgcolor: '#1976d2',
-                                                    color: '#fff',
-                                                    borderRadius: 1,
-                                                    fontWeight: 700,
-                                                    fontSize: 13,
-                                                    letterSpacing: 1,
-                                                    ml: 1,
-                                                }}
-                                            >
-                                                NSP
-                                            </Box>
-                                        )}
-                                    </Box>
-                                    <Typography variant="body2" color="text.secondary">
-                                        DOB: {patient.dob} &nbsp;|&nbsp; Age: {getAge(patient.dob)}
-                                    </Typography>
-                                    <Box mt={1}>
-                                        <Typography variant="body1" component="span" fontWeight={600}>
-                                            Referring:
-                                        </Typography>{' '}
-                                        {patient.referring}
-                                        <br />
-                                        <Typography variant="body1" component="span" fontWeight={600}>
-                                            Consulting:
-                                        </Typography>{' '}
-                                        {patient.consulting}
-                                    </Box>
-                                </Box>
-                                <Button
-                                    variant={isPresented ? 'contained' : 'outlined'}
-                                    color={isPresented ? 'success' : 'primary'}
-                                    onClick={() => togglePresent(patient.id)}
-                                    sx={{ minWidth: 120 }}
-                                >
-                                    {isPresented ? 'Presented' : 'Present'}
-                                </Button>
-                            </Paper>
+                                <CardContent>
+                                    <Stack direction="row" justifyContent="space-between" alignItems="flex-start">
+                                        <Box>
+                                            <Stack direction="row" alignItems="center" spacing={1}>
+                                                <Typography variant="h6" component="div">
+                                                    {patient.name}
+                                                </Typography>
+                                                {patient.status === 'private' && (
+                                                    <Chip label="NSP" color="primary" size="small" />
+                                                )}
+                                            </Stack>
+                                            <Typography variant="body2" color="text.secondary" mt={0.5}>
+                                                DOB: {patient.dob} &nbsp;|&nbsp; Age: {getAge(patient.dob)}
+                                            </Typography>
+                                            <Typography variant="body2" sx={{ mt: 1 }}>
+                                                <strong>Referring:</strong> {patient.referring}
+                                            </Typography>
+                                            <Typography variant="body2">
+                                                <strong>Consulting:</strong> {patient.consulting}
+                                            </Typography>
+                                        </Box>
+                                        <Button
+                                            variant={isPresented ? 'contained' : 'outlined'}
+                                            color={isPresented ? 'success' : 'primary'}
+                                            onClick={() => togglePresent(patient.id)}
+                                            sx={{ minWidth: 120 }}
+                                        >
+                                            {isPresented ? 'Presented' : 'Present'}
+                                        </Button>
+                                    </Stack>
+                                </CardContent>
+                            </Card>
                         )
                     })
                 )}


### PR DESCRIPTION
## Summary
- add app-wide theme wrapper
- switch patient lists to cards
- style dynamic patient page with cards

## Testing
- `npm run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e68de8c30832485d21b9ca2676858