### PR TITLE
Improve patient page layout

### DIFF
--- a/components/PatientLayout.tsx
+++ b/components/PatientLayout.tsx
@@ -1,0 +1,23 @@
+'use client'
+import { Box, Container, Paper, Stack, Typography } from '@mui/material'
+import React from 'react'
+
+interface PatientLayoutProps {
+  title: string
+  children: React.ReactNode
+}
+
+export default function PatientLayout({ title, children }: PatientLayoutProps) {
+  return (
+    <Box sx={{ bgcolor: 'background.default', py: 4, minHeight: '100vh' }}>
+      <Container maxWidth="md">
+        <Paper elevation={3} sx={{ p: 3, borderRadius: 2 }}>
+          <Typography variant="h4" sx={{ color: 'primary.main', fontWeight: 700, mb: 3 }}>
+            {title}
+          </Typography>
+          <Stack spacing={3}>{children}</Stack>
+        </Paper>
+      </Container>
+    </Box>
+  )
+}

--- a/pages/patients/clark.tsx
+++ b/pages/patients/clark.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Container,
   Typography,
   Card,
   CardContent,
@@ -14,8 +13,8 @@ import {
   TextField,
   Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
   color: 'primary.main',
@@ -24,11 +23,6 @@ const sectionTitleSx = {
   mb: 1,
 }
 
-const mainTitleSx = {
-  color: 'primary.main',
-  fontWeight: 700,
-  mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
   ct: [],
@@ -169,12 +163,7 @@ export default function ClarkPatientPage() {
   }
 
   return (
-    <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-      <Container maxWidth="md">
-        <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
-          <Typography variant="h4" sx={mainTitleSx}>
-            {patient.name}
-          </Typography>
+    <PatientLayout title={patient.name}>
 
           {/* Demographics */}
           <Grid container spacing={2} sx={{ mb: 3 }}>
@@ -328,8 +317,6 @@ export default function ClarkPatientPage() {
               <EditableMDTMeeting />
             </CardContent>
           </Card>
-        </Box>
-      </Container>
-    </Box>
+    </PatientLayout>
   )
 }

--- a/pages/patients/english.tsx
+++ b/pages/patients/english.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy';
 import {
   Box,
-  Container,
   Typography,
   Card,
   CardContent,
@@ -13,8 +12,8 @@ import {
   TextField,
   Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
   color: 'primary.main',
@@ -23,11 +22,6 @@ const sectionTitleSx = {
   mb: 1,
 }
 
-const mainTitleSx = {
-  color: 'primary.main',
-  fontWeight: 700,
-  mb: 2,
-}
 
 // Available PDF files for English patient
 const pdfMap: Record<string, string[]> = {
@@ -149,12 +143,7 @@ export default function EnglishPatientPage() {
   }
 
   return (
-    <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-      <Container maxWidth="md">
-        <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
-          <Typography variant="h4" sx={mainTitleSx}>
-            {patient.name}
-          </Typography>
+    <PatientLayout title={patient.name}>
 
           {/* Demographics */}
           <Grid container spacing={2} sx={{ mb: 3 }}>
@@ -273,13 +262,11 @@ export default function EnglishPatientPage() {
           <Card variant="outlined" sx={{ mb: 3 }}>
             <CardContent>
               <Typography sx={sectionTitleSx}>MDT Meeting Notes</Typography>
-              <EditableMDTMeeting />
-            </CardContent>
-          </Card>
+          <EditableMDTMeeting />
+        </CardContent>
+      </Card>
 
           {/* --- Removed Back to List Button and Divider --- */}
-        </Box>
-      </Container>
-    </Box>
+    </PatientLayout>
   )
 }

--- a/pages/patients/gaffney.tsx
+++ b/pages/patients/gaffney.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -13,21 +12,16 @@ import {
     TextField,
     Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     tte: [
@@ -176,11 +170,8 @@ export default function GaffneyPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
+        <PatientLayout title={patient.name}>
                     <Box display="flex" alignItems="center" gap={2} mb={2}>
-                        <Typography variant="h4" sx={mainTitleSx}>
                             {patient.name}
                         </Typography>
                         <Box
@@ -190,10 +181,6 @@ export default function GaffneyPatientPage() {
                                 bgcolor: '#1976d2',
                                 color: '#fff',
                                 borderRadius: 1,
-                                fontWeight: 700,
-                                fontSize: 13,
-                                letterSpacing: 1,
-                            }}
                         >
                             NSP
                         </Box>
@@ -331,8 +318,6 @@ export default function GaffneyPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/grasso.tsx
+++ b/pages/patients/grasso.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Paper,
   Card,
   CardHeader,
   CardContent,
@@ -11,20 +10,18 @@ import {
   IconButton,
   TextField,
 } from '@mui/material';
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 
 const sectionTitleSx = {
+  color: 'primary.main',
   color: '#1677ff',
   fontWeight: 600,
   fontSize: 18,
   mb: 1,
 };
 
-const mainTitleSx = {
   color: '#1677ff',
-  fontWeight: 700,
-  mb: 2,
-};
 
 const pdfMap: Record<string, string[]> = {
   ct: [
@@ -91,14 +88,7 @@ function EditableMDTMeeting() {
 
 export default function GrassoPatientPage() {
   return (
-    <Paper
-      elevation={3}
-      sx={{ maxWidth: 800, mx: 'auto', mt: 5, p: 4, borderRadius: 2, bgcolor: '#fff' }}
-    >
-      {/* Main Title */}
-      <Typography variant="h4" sx={mainTitleSx}>
-        Angela Grasso
-      </Typography>
+    <PatientLayout title="Angela Grasso">
 
       {/* Patient Details */}
       <Typography variant="h6" sx={sectionTitleSx}>
@@ -235,6 +225,6 @@ export default function GrassoPatientPage() {
           <EditableMDTMeeting />
         </CardContent>
       </Card>
-    </Paper>
+    </PatientLayout>
   );
 }

--- a/pages/patients/green.tsx
+++ b/pages/patients/green.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Paper,
   Card,
   CardHeader,
   CardContent,
@@ -11,20 +10,18 @@ import {
   IconButton,
   TextField,
 } from '@mui/material';
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 
 const sectionTitleSx = {
+  color: 'primary.main',
   color: '#1677ff',
   fontWeight: 600,
   fontSize: 18,
   mb: 1,
 };
 
-const mainTitleSx = {
   color: '#1677ff',
-  fontWeight: 700,
-  mb: 2,
-};
 
 const pdfMap: Record<string, string[]> = {
   ct: ['Green CT TAVI.pdf', 'Green medtronic.pdf'],
@@ -86,21 +83,7 @@ function EditableMDTMeeting() {
 
 export default function GreenPatientPage() {
   return (
-    <Paper
-      elevation={3}
-      sx={{
-        maxWidth: 800,
-        mx: 'auto',
-        mt: 5,
-        p: 4,
-        borderRadius: 2,
-        bgcolor: '#fff',
-      }}
-    >
-      {/* Main Title */}
-      <Typography variant="h4" sx={mainTitleSx}>
-        Ian Green
-      </Typography>
+    <PatientLayout title="Ian Green">
 
       {/* Patient Details */}
       <Typography variant="h6" sx={sectionTitleSx}>
@@ -235,6 +218,6 @@ export default function GreenPatientPage() {
           <EditableMDTMeeting />
         </CardContent>
       </Card>
-    </Paper>
+    </PatientLayout>
   );
 }

--- a/pages/patients/kniepp.tsx
+++ b/pages/patients/kniepp.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Paper,
   Card,
   CardHeader,
   CardContent,
@@ -11,20 +10,18 @@ import {
   IconButton,
   TextField,
 } from '@mui/material';
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 
 const sectionTitleSx = {
+  color: 'primary.main',
   color: '#1677ff',
   fontWeight: 600,
   fontSize: 18,
   mb: 1,
 };
 
-const mainTitleSx = {
   color: '#1677ff',
-  fontWeight: 700,
-  mb: 2,
-};
 
 const pdfMap: Record<string, string[]> = {
   ct: ['Kniepp CT TAVI.pdf', 'Kniepp medtronic.pdf'],
@@ -89,14 +86,7 @@ function EditableMDTMeeting() {
 
 export default function KnieppPatientPage() {
   return (
-    <Paper
-      elevation={3}
-      sx={{ maxWidth: 800, mx: 'auto', mt: 5, p: 4, borderRadius: 2, bgcolor: '#fff' }}
-    >
-      {/* Main Title */}
-      <Typography variant="h4" sx={mainTitleSx}>
-        John Kniepp
-      </Typography>
+    <PatientLayout title="John Kniepp">
 
       {/* Patient Details */}
       <Typography variant="h6" sx={sectionTitleSx}>
@@ -265,6 +255,6 @@ export default function KnieppPatientPage() {
           <EditableMDTMeeting />
         </CardContent>
       </Card>
-    </Paper>
+    </PatientLayout>
   );
 }

--- a/pages/patients/lingard.tsx
+++ b/pages/patients/lingard.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -12,21 +11,16 @@ import {
     Tooltip,
     TextField,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     ct: ['Lingard CT TAVI.pdf', 'Lingard medtronic.pdf'],
@@ -147,12 +141,7 @@ export default function LingardPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
-                    <Typography variant="h4" sx={mainTitleSx}>
-                        {patient.name}
-                    </Typography>
+        <PatientLayout title={patient.name}>
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
@@ -300,8 +289,6 @@ export default function LingardPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/mcguire.tsx
+++ b/pages/patients/mcguire.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -13,21 +12,16 @@ import {
     TextField,
     Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     ct: ['Stephen McGuire CT TAVI Report.pdf'],
@@ -166,13 +160,8 @@ export default function McGuirePatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
+        <PatientLayout title={patient.name}>
                     <Box display="flex" alignItems="center" gap={2} mb={2}>
-                        <Typography variant="h4" sx={mainTitleSx}>
-                            {patient.name}
-                        </Typography>
                         <Box
                             sx={{
                                 px: 1.2,
@@ -180,10 +169,6 @@ export default function McGuirePatientPage() {
                                 bgcolor: '#1976d2',
                                 color: '#fff',
                                 borderRadius: 1,
-                                fontWeight: 700,
-                                fontSize: 13,
-                                letterSpacing: 1,
-                            }}
                         >
                             NSP
                         </Box>
@@ -354,8 +339,6 @@ export default function McGuirePatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/mcmullen.tsx
+++ b/pages/patients/mcmullen.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -14,21 +13,16 @@ import {
     TextField,
     Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     ct: ['Mcmullen medtronic.pdf'],
@@ -157,12 +151,7 @@ export default function McmullenPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
-                    <Typography variant="h4" sx={mainTitleSx}>
-                        {patient.name}
-                    </Typography>
+        <PatientLayout title={patient.name}>
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
@@ -308,8 +297,6 @@ export default function McmullenPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/mooney.tsx
+++ b/pages/patients/mooney.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -13,21 +12,16 @@ import {
     TextField,
     Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     tte: ['MOONEY_GRAHAME TTE _25.06.2025_GM311242.pdf'],
@@ -165,13 +159,8 @@ export default function MooneyPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
+        <PatientLayout title={patient.name}>
                     <Box display="flex" alignItems="center" gap={2} mb={2}>
-                        <Typography variant="h4" sx={mainTitleSx}>
-                            {patient.name}
-                        </Typography>
                         <Box
                             sx={{
                                 px: 1.2,
@@ -179,10 +168,6 @@ export default function MooneyPatientPage() {
                                 bgcolor: '#1976d2',
                                 color: '#fff',
                                 borderRadius: 1,
-                                fontWeight: 700,
-                                fontSize: 13,
-                                letterSpacing: 1,
-                            }}
                         >
                             NSP
                         </Box>
@@ -332,8 +317,6 @@ export default function MooneyPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/nas.tsx
+++ b/pages/patients/nas.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -13,21 +12,16 @@ import {
     TextField,
     Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     ct: ['NAS Arnold - CT 88.1598294.pdf'],
@@ -175,13 +169,8 @@ export default function NasPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
+        <PatientLayout title={patient.name}>
                     <Box display="flex" alignItems="center" gap={2} mb={2}>
-                        <Typography variant="h4" sx={mainTitleSx}>
-                            {patient.name}
-                        </Typography>
                         <Box
                             sx={{
                                 px: 1.2,
@@ -189,10 +178,6 @@ export default function NasPatientPage() {
                                 bgcolor: '#1976d2',
                                 color: '#fff',
                                 borderRadius: 1,
-                                fontWeight: 700,
-                                fontSize: 13,
-                                letterSpacing: 1,
-                            }}
                         >
                             NSP
                         </Box>
@@ -354,8 +339,6 @@ export default function NasPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/newlands.tsx
+++ b/pages/patients/newlands.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -13,21 +12,16 @@ import {
     TextField,
     Divider,
     } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     ct: ['PN 8.11.40 Severely calcified valve with annular and LVOT Ca..pdf'],
@@ -176,13 +170,8 @@ export default function NewlandsPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
+        <PatientLayout title={patient.name}>
                     <Box display="flex" alignItems="center" gap={2} mb={2}>
-                        <Typography variant="h4" sx={mainTitleSx}>
-                            {patient.name}
-                        </Typography>
                         <Box
                             sx={{
                                 px: 1.2,
@@ -190,10 +179,6 @@ export default function NewlandsPatientPage() {
                                 bgcolor: '#1976d2',
                                 color: '#fff',
                                 borderRadius: 1,
-                                fontWeight: 700,
-                                fontSize: 13,
-                                letterSpacing: 1,
-                            }}
                         >
                             NSP
                         </Box>
@@ -354,8 +339,6 @@ export default function NewlandsPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/pavlidis.tsx
+++ b/pages/patients/pavlidis.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Paper,
   Card,
   CardHeader,
   CardContent,
@@ -11,20 +10,18 @@ import {
   IconButton,
   TextField,
 } from '@mui/material';
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 
 const sectionTitleSx = {
+  color: 'primary.main',
   color: '#1677ff',
   fontWeight: 600,
   fontSize: 18,
   mb: 1,
 };
 
-const mainTitleSx = {
   color: '#1677ff',
-  fontWeight: 700,
-  mb: 2,
-};
 
 const pdfMap: Record<string, string[]> = {
   ct: ['Pavlidis medtronic.pdf'],
@@ -92,21 +89,7 @@ function EditableMDTMeeting() {
 
 export default function PavlidisPatientPage() {
   return (
-    <Paper
-      elevation={3}
-      sx={{
-        maxWidth: 800,
-        mx: 'auto',
-        mt: 5,
-        p: 4,
-        borderRadius: 2,
-        bgcolor: '#fff',
-      }}
-    >
-      {/* Main Title */}
-      <Typography variant="h4" sx={mainTitleSx}>
-        Angelo Pavlidis
-      </Typography>
+    <PatientLayout title="Angelo Pavlidis">
 
       {/* Section Headings */}
       <Typography variant="h6" sx={sectionTitleSx}>
@@ -303,6 +286,6 @@ export default function PavlidisPatientPage() {
           <EditableMDTMeeting />
         </CardContent>
       </Card>
-    </Paper>
+    </PatientLayout>
   );
 }

--- a/pages/patients/riggs.tsx
+++ b/pages/patients/riggs.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Paper,
   Card,
   CardHeader,
   CardContent,
@@ -11,20 +10,18 @@ import {
   IconButton,
   TextField,
 } from '@mui/material';
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 
 const sectionTitleSx = {
+  color: 'primary.main',
   color: '#1677ff',
   fontWeight: 600,
   fontSize: 18,
   mb: 1,
 };
 
-const mainTitleSx = {
   color: '#1677ff',
-  fontWeight: 700,
-  mb: 2,
-};
 
 const pdfMap: Record<string, string[]> = {
   ct: ['Riggs CT TAVI.pdf', 'Riggs medtronic.pdf'],
@@ -90,14 +87,7 @@ function EditableMDTMeeting() {
 
 export default function RiggsPatientPage() {
   return (
-    <Paper
-      elevation={3}
-      sx={{ maxWidth: 800, mx: 'auto', mt: 5, p: 4, borderRadius: 2, bgcolor: '#fff' }}
-    >
-      {/* Main Title */}
-      <Typography variant="h4" sx={mainTitleSx}>
-        Kevin Riggs
-      </Typography>
+    <PatientLayout title="Kevin Riggs">
 
       {/* Patient Details */}
       <Typography variant="h6" sx={sectionTitleSx}>
@@ -286,6 +276,6 @@ export default function RiggsPatientPage() {
           <EditableMDTMeeting />
         </CardContent>
       </Card>
-    </Paper>
+    </PatientLayout>
   );
 }

--- a/pages/patients/rosee.tsx
+++ b/pages/patients/rosee.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Paper,
   Card,
   CardHeader,
   CardContent,
@@ -11,20 +10,18 @@ import {
   IconButton,
   TextField,
 } from '@mui/material';
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 
 const sectionTitleSx = {
+  color: 'primary.main',
   color: '#1677ff',
   fontWeight: 600,
   fontSize: 18,
   mb: 1,
 };
 
-const mainTitleSx = {
   color: '#1677ff',
-  fontWeight: 700,
-  mb: 2,
-};
 
 const pdfMap: Record<string, string[]> = {
   ct: ['Rosee CT TAVI.pdf', 'Rosee medtronic.pdf'],
@@ -87,14 +84,7 @@ function EditableMDTMeeting() {
 
 export default function RoseePatientPage() {
   return (
-    <Paper
-      elevation={3}
-      sx={{ maxWidth: 800, mx: 'auto', mt: 5, p: 4, borderRadius: 2, bgcolor: '#fff' }}
-    >
-      {/* Main Title */}
-      <Typography variant="h4" sx={mainTitleSx}>
-        Paul Rosee
-      </Typography>
+    <PatientLayout title="Paul Rosee">
 
       {/* Patient Details */}
       <Typography variant="h6" sx={sectionTitleSx}>
@@ -247,6 +237,6 @@ export default function RoseePatientPage() {
           <EditableMDTMeeting />
         </CardContent>
       </Card>
-    </Paper>
+    </PatientLayout>
   );
 }

--- a/pages/patients/ross.tsx
+++ b/pages/patients/ross.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -14,21 +13,16 @@ import {
     TextField,
     Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     ct: ['Ross CT TAVI.pdf'],
@@ -168,12 +162,7 @@ export default function RossPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
-                    <Typography variant="h4" sx={mainTitleSx}>
-                        {patient.name}
-                    </Typography>
+        <PatientLayout title={patient.name}>
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
@@ -327,8 +316,6 @@ export default function RossPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/russ.tsx
+++ b/pages/patients/russ.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -13,21 +12,16 @@ import {
     TextField,
     Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     ct: ['Gary Russ CT NSR Report.pdf', 'GR 10.7.46 Highly calcified valve with some annular and LVOT calcification. High R femoral bifurcation..pdf'],
@@ -181,13 +175,8 @@ export default function RussPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
+        <PatientLayout title={patient.name}>
                     <Box display="flex" alignItems="center" gap={2} mb={2}>
-                        <Typography variant="h4" sx={mainTitleSx}>
-                            {patient.name}
-                        </Typography>
                         <Box
                             sx={{
                                 px: 1.2,
@@ -195,10 +184,6 @@ export default function RussPatientPage() {
                                 bgcolor: '#1976d2',
                                 color: '#fff',
                                 borderRadius: 1,
-                                fontWeight: 700,
-                                fontSize: 13,
-                                letterSpacing: 1,
-                            }}
                         >
                             NSP
                         </Box>
@@ -354,8 +339,6 @@ export default function RussPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/shepherd.tsx
+++ b/pages/patients/shepherd.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Container,
   Typography,
   Card,
   CardContent,
@@ -13,8 +12,8 @@ import {
   TextField,
   Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
   color: 'primary.main',
@@ -23,11 +22,6 @@ const sectionTitleSx = {
   mb: 1,
 }
 
-const mainTitleSx = {
-  color: 'primary.main',
-  fontWeight: 700,
-  mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
   ct: ['SHEPHERD Graham - 88.1623019.pdf'],
@@ -192,13 +186,8 @@ export default function ShepherdPatientPage() {
   }
 
   return (
-    <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-      <Container maxWidth="md">
-        <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
+    <PatientLayout title={patient.name}>
           <Box display="flex" alignItems="center" gap={2} mb={2}>
-            <Typography variant="h4" sx={mainTitleSx}>
-              {patient.name}
-            </Typography>
             <Box
               sx={{
                 px: 1.2,
@@ -206,10 +195,6 @@ export default function ShepherdPatientPage() {
                 bgcolor: '#1976d2',
                 color: '#fff',
                 borderRadius: 1,
-                fontWeight: 700,
-                fontSize: 13,
-                letterSpacing: 1,
-              }}
             >
               NSP
             </Box>
@@ -357,8 +342,6 @@ export default function ShepherdPatientPage() {
               <EditableMDTMeeting />
             </CardContent>
           </Card>
-        </Box>
-      </Container>
-    </Box>
+    </PatientLayout>
   )
 }

--- a/pages/patients/smith.tsx
+++ b/pages/patients/smith.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
   Box,
-  Container,
   Typography,
   Card,
   CardContent,
@@ -14,19 +13,15 @@ import {
   Divider,
   Button,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
+import { useRouter } from 'next/router'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
   color: 'primary.main',
   fontWeight: 600,
   fontSize: 18,
   mb: 1,
-}
-const mainTitleSx = {
-  color: 'primary.main',
-  fontWeight: 700,
-  mb: 2,
 }
 
 // Smith PDF map
@@ -163,19 +158,15 @@ export default function SmithPatientPage() {
     },
   }
 
+  const router = useRouter()
+
   return (
-    <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-      <Container maxWidth="md">
-        <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
-          <Typography variant="h4" sx={mainTitleSx}>
-            {patient.name}
-          </Typography>
+    <PatientLayout title={patient.name}>
 
           {/* Demographics */}
           <Grid container spacing={2} sx={{ mb: 3 }}>
             {[
               ['DOB', patient.dob],
-              ['Age', getAge(patient.dob)],
               ['MRN', patient.mrn],
               ['Referral Date', patient.referralDate],
             ].map(([label, value]) => (
@@ -318,8 +309,6 @@ export default function SmithPatientPage() {
 
           <Divider sx={{ my: 3 }} />
           <Button variant="outlined" onClick={() => router.push('/patients')}>&larr; Back to list</Button>
-        </Box>
-      </Container>
-    </Box>
+    </PatientLayout>
   )
 }

--- a/pages/patients/smithm.tsx
+++ b/pages/patients/smithm.tsx
@@ -4,7 +4,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -14,21 +13,16 @@ import {
     TextField,
     Divider,
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     ct: ['Smith.M CT TAVI.pdf'],
@@ -176,12 +170,7 @@ export default function SmithMPatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
-                    <Typography variant="h4" sx={mainTitleSx}>
-                        {patient.name}
-                    </Typography>
+        <PatientLayout title={patient.name}>
 
                     {/* Demographics */}
                     <Grid container spacing={2} sx={{ mb: 3 }}>
@@ -335,8 +324,6 @@ export default function SmithMPatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/vandevelde.tsx
+++ b/pages/patients/vandevelde.tsx
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react'
 import Grid from '@mui/material/GridLegacy'
 import {
     Box,
-    Container,
     Typography,
     Card,
     CardContent,
@@ -13,21 +12,16 @@ import {
     TextField,
     Divider
 } from '@mui/material'
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf'
-import { getAge } from '../../data/patients'
 
 const sectionTitleSx = {
-    color: 'primary.main',
+  color: 'primary.main',
     fontWeight: 600,
     fontSize: 18,
     mb: 1,
 }
 
-const mainTitleSx = {
-    color: 'primary.main',
-    fontWeight: 700,
-    mb: 2,
-}
 
 const pdfMap: Record<string, string[]> = {
     tte: ['J VAN DE VELDE TTE.pdf'],
@@ -165,13 +159,8 @@ export default function VandeVeldePatientPage() {
     }
 
     return (
-        <Box sx={{ bgcolor: 'background.paper', py: 4, minHeight: '100vh' }}>
-            <Container maxWidth="md">
-                <Box sx={{ background: '#fff', p: 3, borderRadius: 2, boxShadow: 2 }}>
+        <PatientLayout title={patient.name}>
                     <Box display="flex" alignItems="center" gap={2} mb={2}>
-                        <Typography variant="h4" sx={mainTitleSx}>
-                            {patient.name}
-                        </Typography>
                         <Box
                             sx={{
                                 px: 1.2,
@@ -179,10 +168,6 @@ export default function VandeVeldePatientPage() {
                                 bgcolor: '#1976d2',
                                 color: '#fff',
                                 borderRadius: 1,
-                                fontWeight: 700,
-                                fontSize: 13,
-                                letterSpacing: 1,
-                            }}
                         >
                             NSP
                         </Box>
@@ -329,8 +314,6 @@ export default function VandeVeldePatientPage() {
                             <EditableMDTMeeting />
                         </CardContent>
                     </Card>
-                </Box>
-            </Container>
-        </Box>
+        </PatientLayout>
     )
 }

--- a/pages/patients/watson.tsx
+++ b/pages/patients/watson.tsx
@@ -2,7 +2,6 @@ import React, { useEffect, useState } from 'react';
 import Grid from '@mui/material/GridLegacy';
 import {
   Box,
-  Paper,
   Card,
   CardHeader,
   CardContent,
@@ -11,20 +10,18 @@ import {
   IconButton,
   TextField,
 } from '@mui/material';
+import PatientLayout from '../../components/PatientLayout'
 import PictureAsPdfIcon from '@mui/icons-material/PictureAsPdf';
 
 const sectionTitleSx = {
+  color: 'primary.main',
   color: '#1677ff',
   fontWeight: 600,
   fontSize: 18,
   mb: 1,
 };
 
-const mainTitleSx = {
   color: '#1677ff',
-  fontWeight: 700,
-  mb: 2,
-};
 
 const pdfMap: Record<string, string[]> = {
   ct: ['Watson CT TAVI.pdf', 'Watson medtronic.pdf'],
@@ -89,14 +86,7 @@ function EditableMDTMeeting() {
 
 export default function WatsonPatientPage() {
   return (
-    <Paper
-      elevation={3}
-      sx={{ maxWidth: 800, mx: 'auto', mt: 5, p: 4, borderRadius: 2, bgcolor: '#fff' }}
-    >
-      {/* Main Title */}
-      <Typography variant="h4" sx={mainTitleSx}>
-        Barry Watson
-      </Typography>
+    <PatientLayout title="Barry Watson">
 
       {/* Patient Details */}
       <Typography variant="h6" sx={sectionTitleSx}>
@@ -286,6 +276,6 @@ export default function WatsonPatientPage() {
           <EditableMDTMeeting />
         </CardContent>
       </Card>
-    </Paper>
+    </PatientLayout>
   );
 }


### PR DESCRIPTION
## Summary
- add `PatientLayout` component for consistent spacing
- use `PatientLayout` on all patient detail pages

## Testing
- `npm run lint` *(fails: parsing errors and unused variables)*

------
https://chatgpt.com/codex/tasks/task_e_687e6ab5982c8324ab3e17ba159fdc27