### PR TITLE
Fix nested title element in Watson patient page

### DIFF
--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -1,15 +1,91 @@
-import React from 'react';
-import { Row, Col, Space, Button as AntButton, Card as AntCard, Typography as AntTypography, Tooltip as AntTooltip, Tag, Input, Divider as AntDivider } from 'antd';
+import React, { CSSProperties, HTMLAttributes, ReactNode } from 'react';
+import {
+  Row,
+  Col,
+  Space,
+  Button as AntButton,
+  Card as AntCard,
+  Typography as AntTypography,
+  Tooltip as AntTooltip,
+  Tag,
+  Input,
+  Divider as AntDivider,
+} from 'antd';
 import { FilePdfOutlined } from '@ant-design/icons';
+
+interface StyledProps {
+  sx?: CSSProperties;
+  style?: CSSProperties;
+}
+
+export interface BoxProps extends HTMLAttributes<HTMLDivElement>, StyledProps {}
+
+export interface ContainerProps extends BoxProps {
+  maxWidth?: keyof typeof maxWidthMap;
+}
+
+export interface TypographyProps
+  extends HTMLAttributes<HTMLElement>, StyledProps {
+  variant?: 'h4' | 'h6' | 'subtitle2';
+  gutterBottom?: boolean;
+  align?: 'left' | 'right' | 'center' | 'justify';
+}
+
+export interface CardProps extends React.ComponentProps<typeof AntCard>, StyledProps {
+  variant?: string;
+}
+
+export interface ButtonProps extends React.ComponentProps<typeof AntButton>, StyledProps {
+  variant?: 'contained' | 'text' | 'outlined';
+  fullWidth?: boolean;
+}
+
+export interface ChipProps extends React.ComponentProps<typeof Tag> {
+  label: ReactNode;
+  color?: string;
+}
+
+export interface StackProps extends StyledProps {
+  direction?: 'row' | 'column';
+  spacing?: number;
+  justifyContent?: string;
+  alignItems?: string;
+  children?: ReactNode;
+}
+
+export interface GridProps extends StyledProps {
+  container?: boolean;
+  spacing?: number;
+  xs?: number;
+  sm?: number;
+  children?: ReactNode;
+}
+
+
+export interface TextFieldProps extends React.ComponentProps<typeof Input> {
+  multiline?: boolean;
+  minRows?: number;
+  maxRows?: number;
+  fullWidth?: boolean;
+  sx?: CSSProperties;
+  style?: CSSProperties;
+}
+
+export interface PaperProps extends React.ComponentProps<typeof AntCard>, StyledProps {}
+
+export interface CardHeaderProps extends HTMLAttributes<HTMLDivElement>, StyledProps {
+  title: ReactNode;
+  action?: ReactNode;
+}
 
 export const PdfIcon = FilePdfOutlined;
 
-export function Box({ sx, style, ...props }: any) {
+export function Box({ sx, style, ...props }: BoxProps) {
   return <div style={{ ...(sx || {}), ...(style || {}) }} {...props} />;
 }
 
 const maxWidthMap: Record<string, number> = { sm: 600, md: 960, lg: 1280 };
-export function Container({ sx, style, maxWidth = 'md', ...props }: any) {
+export function Container({ sx, style, maxWidth = 'md', ...props }: ContainerProps) {
   return (
     <div
       style={{ margin: '0 auto', width: '100%', maxWidth: maxWidthMap[maxWidth] || maxWidthMap.md, padding: '0 16px', ...(sx || {}), ...(style || {}) }}
@@ -19,7 +95,7 @@ export function Container({ sx, style, maxWidth = 'md', ...props }: any) {
 }
 
 const { Title, Text } = AntTypography;
-export function Typography({ variant, sx, style, gutterBottom, align, ...props }: any) {
+export function Typography({ variant, sx, style, gutterBottom, align, ...props }: TypographyProps) {
   const combined = { marginBottom: gutterBottom ? '0.35em' : undefined, textAlign: align, ...(sx || {}), ...(style || {}) };
   const children = props.children;
   if (variant === 'h4') return <Title level={4} style={combined} {...props}>{children}</Title>;
@@ -28,25 +104,33 @@ export function Typography({ variant, sx, style, gutterBottom, align, ...props }
   return <Text style={combined} {...props}>{children}</Text>;
 }
 
-export function Card({ variant, elevation, sx, style, ...props }: any) {
+export function Card({ variant, sx, style, ...props }: CardProps) {
   return <AntCard bordered={variant !== 'outlined'} style={{ ...(sx || {}), ...(style || {}) }} {...props} />;
 }
 
-export function CardContent(props: any) {
+export function CardContent(props: HTMLAttributes<HTMLDivElement>) {
   return <div {...props} />;
 }
 
-export function Button({ variant, fullWidth, sx, style, ...props }: any) {
-  const type = variant === 'contained' ? 'primary' : variant === 'text' ? 'link' : 'default';
+export function Button({ variant, fullWidth, sx, style, ...props }: ButtonProps) {
+  const typeValue: 'primary' | 'link' | 'default' | undefined =
+    variant === 'contained' ? 'primary' : variant === 'text' ? 'link' : 'default';
   const ghost = variant === 'outlined';
-  return <AntButton type={type as any} ghost={ghost} style={{ width: fullWidth ? '100%' : undefined, ...(sx || {}), ...(style || {}) }} {...props} />;
+  return (
+    <AntButton
+      type={typeValue}
+      ghost={ghost}
+      style={{ width: fullWidth ? '100%' : undefined, ...(sx || {}), ...(style || {}) }}
+      {...props}
+    />
+  );
 }
 
-export function Chip({ label, color, ...rest }: any) {
+export function Chip({ label, color, ...rest }: ChipProps) {
   return <Tag color={color === 'primary' ? 'blue' : color} {...rest}>{label}</Tag>;
 }
 
-export function Stack({ direction = 'column', spacing = 1, justifyContent, alignItems, sx, style, children, ...rest }: any) {
+export function Stack({ direction = 'column', spacing = 1, justifyContent, alignItems, sx, style, children, ...rest }: StackProps) {
   return (
     <Space
       direction={direction === 'row' ? 'horizontal' : 'vertical'}
@@ -59,19 +143,19 @@ export function Stack({ direction = 'column', spacing = 1, justifyContent, align
   );
 }
 
-export function Grid({ container, item, spacing, xs, sm, sx, style, children, ...rest }: any) {
+export function Grid({ container, spacing, xs, sm, sx, style, children, ...rest }: GridProps) {
   if (container) {
     return <Row gutter={spacing ? spacing * 8 : 0} style={{ ...(sx || {}), ...(style || {}) }} {...rest}>{children}</Row>;
   }
   return <Col xs={xs ? xs * 2 : undefined} sm={sm ? sm * 2 : undefined} style={{ ...(sx || {}), ...(style || {}) }} {...rest}>{children}</Col>;
 }
 
-export function IconButton(props: any) {
+export function IconButton(props: React.ComponentProps<typeof AntButton>) {
   return <AntButton shape="circle" {...props} />;
 }
 
 export const Tooltip = AntTooltip;
-export function TextField({ multiline, minRows, maxRows, fullWidth, sx, style, ...props }: any) {
+export function TextField({ multiline, minRows, maxRows, fullWidth, sx, style, ...props }: TextFieldProps) {
   if (multiline) {
     return <Input.TextArea autoSize={{ minRows, maxRows }} style={{ width: fullWidth ? '100%' : undefined, ...(sx || {}), ...(style || {}) }} {...props} />;
   }
@@ -80,11 +164,11 @@ export function TextField({ multiline, minRows, maxRows, fullWidth, sx, style, .
 
 export const Divider = AntDivider;
 
-export function Paper({ elevation, sx, style, ...props }: any) {
+export function Paper({ sx, style, ...props }: PaperProps) {
   return <AntCard bordered style={{ ...(sx || {}), ...(style || {}) }} {...props} />;
 }
 
-export function CardHeader({ title, action, sx, style, ...rest }: any) {
+export function CardHeader({ title, action, sx, style, ...rest }: CardHeaderProps) {
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', padding: '16px', ...(sx || {}), ...(style || {}) }} {...rest}>
       <div>{title}</div>

--- a/pages/patients/watson.tsx
+++ b/pages/patients/watson.tsx
@@ -12,7 +12,7 @@ const doc = allPatients.find(p => p.id === 'watson')!;        // quick lookup
 
 export default function WatsonPage() {
   return (
-    <PatientLayout title={<Title level={3}>{doc.name}</Title>}>
+    <PatientLayout title={doc.name}>
       <DemographicsGrid data={{
         DOB: doc.dob,
         Age: getAge(doc.dob),


### PR DESCRIPTION
## Summary
- fix Watson patient page title to avoid nested `<h3>` tags
- replace `any` types in shared UI helpers to satisfy lint

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68878d17c2648324823477e4f7009e46