### PR TITLE
Fix Next.js build by transpiling rc-pagination

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -11,6 +11,7 @@ const nextConfig: NextConfig = {
     'rc-util',
     'rc-picker',
     'rc-trigger',
+    'rc-pagination',
   ],
 
   // Disable ESLint during builds to allow type-unsafe utility components


### PR DESCRIPTION
## Summary
- add `rc-pagination` to transpilePackages to avoid runtime "Unexpected token 'export'" error

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6887cda660f08324a1539a039dea54fd