### PR TITLE
Add MitraClip badge to patient list

### DIFF
--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -159,11 +159,11 @@ export function TextField({ multiline, minRows, maxRows, fullWidth, sx, style, .
       <Input.TextArea
         autoSize={{ minRows, maxRows }}
         style={{ width: fullWidth ? '100%' : undefined, ...(sx || {}), ...(style || {}) }}
-        {...(props as any)}
+        {...props}
       />
     );
   }
-  return <Input style={{ width: fullWidth ? '100%' : undefined, ...(sx || {}), ...(style || {}) }} {...(props as any)} />;
+  return <Input style={{ width: fullWidth ? '100%' : undefined, ...(sx || {}), ...(style || {}) }} {...props} />;
 }
 
 export const Divider = AntDivider;

--- a/pages/patients/index.tsx
+++ b/pages/patients/index.tsx
@@ -49,7 +49,14 @@ export default function Patients() {
                                     >
                                         <Typography.Title level={5} style={{ margin: 0 }}>
                                             {patient.name}{' '}
-                                            {patient.status === 'private' && <Tag color="blue">NSP</Tag>}
+                                            {patient.status === 'private' && (
+                                                <Tag color="blue">NSP</Tag>
+                                            )}
+                                            {patient.badges?.map((badge) => (
+                                                <Tag key={badge} color="purple">
+                                                    {badge}
+                                                </Tag>
+                                            ))}
                                         </Typography.Title>
 
                                         <Button


### PR DESCRIPTION
## Summary
- show procedure badges (e.g., MitraClip) alongside existing NSP tag on patient list
- tidy TextField component typing to satisfy lint rules

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68904f117140832485c8796f5e56e37d