### PR TITLE
Fix TextField multiline build error

### DIFF
--- a/components/ui.tsx
+++ b/components/ui.tsx
@@ -155,11 +155,17 @@ export function IconButton(props: React.ComponentProps<typeof AntButton>) {
 export const Tooltip = AntTooltip;
 export function TextField({ multiline, minRows, maxRows, fullWidth, sx, style, ...props }: TextFieldProps) {
   if (multiline) {
+    // Input.TextArea expects a different prop type than Input.
+    // Remove unsupported props (e.g. `prefix`) before spreading the rest
+    // to avoid type incompatibilities during compilation.
+    const { prefix: _prefix, ...rest } =
+      (props as React.ComponentProps<typeof Input.TextArea> & { prefix?: React.ReactNode });
+    void _prefix;
     return (
       <Input.TextArea
         autoSize={{ minRows, maxRows }}
         style={{ width: fullWidth ? '100%' : undefined, ...(sx || {}), ...(style || {}) }}
-        {...props}
+        {...rest}
       />
     );
   }


### PR DESCRIPTION
## Summary
- ignore unsupported props when rendering multiline TextField to satisfy Ant Design typings

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6890634169188324b40ff61c9a108a77