### PR TITLE
feat: add patient list filters

### DIFF
--- a/pages/patients/index.tsx
+++ b/pages/patients/index.tsx
@@ -1,12 +1,38 @@
 'use client'
 
 import { useState } from 'react'
-import { List, Card, Button, Tag, Typography } from 'antd'
+import { List, Card, Button, Tag, Typography, Checkbox, Space } from 'antd'
 import { allPatients, Patient, getAge } from '../../data/patients'
 
 export default function Patients() {
     /* keep only runtime state */
     const [presentedIds, setPresentedIds] = useState<string[]>([])
+    const [filters, setFilters] = useState({
+        Hansen: true,
+        Bhindi: true,
+        TAVI: true,
+        MitraClip: true,
+        TriClip: true,
+        Presented: true,
+        Private: true,
+        Public: true,
+    })
+
+    const filteredPatients = allPatients.filter((patient) => {
+        if (!filters.Hansen && patient.consulting.includes('Hansen')) return false
+        if (!filters.Bhindi && patient.consulting.includes('Bhindi')) return false
+        if (!filters.TAVI && patient.badges?.includes('TAVI')) return false
+        if (!filters.MitraClip && patient.badges?.includes('MitraClip')) return false
+        if (!filters.TriClip && patient.badges?.includes('TriClip')) return false
+        if (!filters.Private && patient.status === 'private') return false
+        if (!filters.Public && patient.status === 'public') return false
+        if (!filters.Presented && presentedIds.includes(patient.id)) return false
+        return true
+    })
+
+    const handleFilterChange = (name: keyof typeof filters) => (e: any) => {
+        setFilters((prev) => ({ ...prev, [name]: e.target.checked }))
+    }
 
     const togglePresent = (id: string) => {
         setPresentedIds((prev) =>
@@ -24,12 +50,62 @@ export default function Patients() {
             bordered={false}
             style={{ maxWidth: 800, margin: '32px auto' }}
         >
-            {allPatients.length === 0 ? (
-                <Typography.Text>All patients presented!</Typography.Text>
+            <Space style={{ marginBottom: 16 }} wrap>
+                <Checkbox
+                    checked={filters.Hansen}
+                    onChange={handleFilterChange('Hansen')}
+                >
+                    Hansen
+                </Checkbox>
+                <Checkbox
+                    checked={filters.Bhindi}
+                    onChange={handleFilterChange('Bhindi')}
+                >
+                    Bhindi
+                </Checkbox>
+                <Checkbox
+                    checked={filters.TAVI}
+                    onChange={handleFilterChange('TAVI')}
+                >
+                    TAVI
+                </Checkbox>
+                <Checkbox
+                    checked={filters.MitraClip}
+                    onChange={handleFilterChange('MitraClip')}
+                >
+                    MitraClip
+                </Checkbox>
+                <Checkbox
+                    checked={filters.TriClip}
+                    onChange={handleFilterChange('TriClip')}
+                >
+                    TriClip
+                </Checkbox>
+                <Checkbox
+                    checked={filters.Presented}
+                    onChange={handleFilterChange('Presented')}
+                >
+                    Presented
+                </Checkbox>
+                <Checkbox
+                    checked={filters.Private}
+                    onChange={handleFilterChange('Private')}
+                >
+                    Private
+                </Checkbox>
+                <Checkbox
+                    checked={filters.Public}
+                    onChange={handleFilterChange('Public')}
+                >
+                    Public
+                </Checkbox>
+            </Space>
+            {filteredPatients.length === 0 ? (
+                <Typography.Text>No patients match filters</Typography.Text>
             ) : (
                 <List
                     itemLayout="vertical"
-                    dataSource={allPatients}
+                    dataSource={filteredPatients}
                     renderItem={(patient: Patient) => {
                         const presented = presentedIds.includes(patient.id)
                         return (


### PR DESCRIPTION
## Summary
- add checkbox filters for doctor, procedure, status, and presentation
- hide patients that don't match active filters

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6890a2c9ff6883248be25ac5e45be873