### PR TITLE
Add patient PDF link checker and CI verification

### DIFF
--- a/.github/workflows/pdf-check.yaml
+++ b/.github/workflows/pdf-check.yaml
@@ -1,0 +1,17 @@
+name: Verify patient PDFs
+
+on:
+  pull_request:
+  push:
+    branches: [ main ]
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "check-pdfs": "node scripts/check-pdfs.js",
+    "test": "npm run lint && npm run check-pdfs"
   },
   "dependencies": {
     "@ant-design/icons": "^5.2.5",

--- a/scripts/check-pdfs.js
+++ b/scripts/check-pdfs.js
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const patientDir = path.join(__dirname, '..', 'data', 'patients');
+const pdfDir = path.join(__dirname, '..', 'public', 'pdfs');
+
+// Get patient files (.ts or .tsx) excluding index and types
+const patientFiles = fs
+  .readdirSync(patientDir)
+  .filter((f) => /(\.ts|\.tsx)$/.test(f) && !['index.ts', 'types.ts'].includes(f));
+
+let missing = [];
+for (const file of patientFiles) {
+  const content = fs.readFileSync(path.join(patientDir, file), 'utf8');
+  const pdfSection = content.match(/pdfs:\s*{([\s\S]*?)}/);
+  if (!pdfSection) continue;
+  const pdfs = [...pdfSection[1].matchAll(/'([^']+\.pdf)'/g)].map((m) => m[1]);
+  for (const pdf of pdfs) {
+    const pdfPath = path.join(pdfDir, pdf);
+    if (!fs.existsSync(pdfPath)) {
+      missing.push(`${file}: ${pdf}`);
+    }
+  }
+}
+
+if (missing.length > 0) {
+  console.error('Missing PDF files:');
+  for (const m of missing) console.error(`- ${m}`);
+  process.exit(1);
+} else {
+  console.log('All referenced PDF files are present.');
+}


### PR DESCRIPTION
## Summary
- add a Node script that checks whether each patient PDF referenced in the data exists
- expose the script via `npm test` and run it in a new GitHub workflow

## Testing
- `npm test` *(fails: missing PDF files reported)*

------
https://chatgpt.com/codex/tasks/task_e_68929516c2a8832487498c3de1c47852