### PR TITLE
Add investigation summary type and fix patient import

### DIFF
--- a/data/patients/index.ts
+++ b/data/patients/index.ts
@@ -18,7 +18,6 @@ import moelle from './moelle';
 import low from './low';
 import dunbar from './dunbar';
 import washington from './washington';
-import stevenson from './stevenson';
 
 export const allPatients: Patient[] = [
   newbould,

--- a/data/patients/types.ts
+++ b/data/patients/types.ts
@@ -34,6 +34,7 @@ export interface Patient {
   ctsSummary?: string;
   cognitive?: Record<string, string | number | null>;
   bloods?: Record<string, string | number | null>;
+  investigationSummary?: Record<string, string | string[]>;
   agedCare?: string;
   agedCareNote?: string;
   consultTexts?: Record<string, string>;


### PR DESCRIPTION
## Summary
- allow `investigationSummary` in `Patient` type so existing patient data compiles
- remove duplicate `stevenson` import from patient index

## Testing
- `npm run build`
- `npm test` *(fails: Missing PDF files)*

------
https://chatgpt.com/codex/tasks/task_e_68997a8f7f3c8324915667f3d9cd341b