### PR TITLE
fix: expand patient types for successful build

### DIFF
--- a/data/patients/newbould.ts
+++ b/data/patients/newbould.ts
@@ -80,7 +80,7 @@ const patient: Patient = {
     CRP: '1.7',
   },
 
-  investigationsSummary: {
+  investigationSummary: {
     tte: [
       {
         date: '2025-07-16',

--- a/data/patients/types.ts
+++ b/data/patients/types.ts
@@ -1,5 +1,25 @@
 import React from 'react';
 
+export interface InvestigationDetail {
+  date: string;
+  summary: string;
+  source: string[];
+}
+
+export interface ConsultRecord {
+  date: string;
+  clinician: string;
+  outcome: string;
+  source: string[];
+}
+
+export interface SimpleConsult {
+  clinician: string;
+  recommendation: string;
+}
+
+export type Consults = ConsultRecord[] | Record<string, SimpleConsult>;
+
 export interface Patient {
   id: string;
   name: string;
@@ -18,6 +38,7 @@ export interface Patient {
   history?: string[];
   background?: string[];
   medications?: string[];
+  allergies?: string[];
   social?: string;
   functional?: string;
   tteSummary?: string[];
@@ -34,10 +55,11 @@ export interface Patient {
   ctsSummary?: string;
   cognitive?: Record<string, string | number | null>;
   bloods?: Record<string, string | number | null>;
-  investigationSummary?: Record<string, string | string[]>;
+  investigationSummary?: Record<string, string | string[] | InvestigationDetail[]>;
   agedCare?: string;
   agedCareNote?: string;
   consultTexts?: Record<string, string>;
+  consults?: Consults;
   pelvicReport?: React.ReactNode;
   /** public = MDT list; private = NSP list */
   status?: 'public' | 'private';


### PR DESCRIPTION
## Summary
- add InvestigationDetail and Consult types to support structured data
- allow patients to include allergies and consult records
- fix Newbould patient to use investigationSummary

## Testing
- `npm run build`
- `npm run check-pdfs` *(missing: Gaffney referral.pdf, Gaffney TTE.pdf, Gaffney ECG.pdf, Gaffney CT 2025.pdf, Gaffney aged care.pdf, Shepherd TTE.pdf, Shepherd Angio.pdf, Shepherd ECG.pdf, Shepherd CT.pdf, Shepherd Aged Care.pdf)*

------
https://chatgpt.com/codex/tasks/task_e_6899881396c88324a4c8943707a863e0