### PR TITLE
chore: retain docker cache for faster deploy

### DIFF
--- a/scripts/deploy-ravitracker.sh
+++ b/scripts/deploy-ravitracker.sh
@@ -13,12 +13,16 @@ git reset --hard origin/main
 git clean -fdx
 
 # Build & (re)run
-docker build --pull -t ravitracker-frontend .
+if docker image inspect ravitracker-frontend >/dev/null 2>&1; then
+  CACHE_FROM="--cache-from=ravitracker-frontend"
+else
+  CACHE_FROM=""
+fi
+docker build --pull $CACHE_FROM -t ravitracker-frontend .
 docker rm -f ravitracker-frontend 2>/dev/null || true
 
-# Free space
-docker container prune -f
-docker image prune -f
+# Retain Docker cache to speed up subsequent builds.
+# Prune images/containers manually if disk space becomes an issue.
 
 docker run -d \
   --name ravitracker-frontend \


### PR DESCRIPTION
## Summary
- speed up production deploy by reusing prior Docker layers instead of pruning them each run
- add conditional `--cache-from` to build step and keep images/containers for caching

## Testing
- `npm test` *(fails: missing PDF files `Gaffney referral.pdf`, `Gaffney TTE.pdf`, `Gaffney ECG.pdf`, `Gaffney CT 2025.pdf`, `Gaffney aged care.pdf`)*

------
https://chatgpt.com/codex/tasks/task_e_6899bc8b96d083248f543311391a5a86