### PR TITLE
Remove leftover contentReference tags from patient files

### DIFF
--- a/data/patients/bogle.ts
+++ b/data/patients/bogle.ts
@@ -16,29 +16,28 @@ const patient: Patient = {
 
   pdfs: {
     tte: [
-      'Bogle Gosford TTE 23.5.25.pdf', // Severe AS; AVA 0.81 cm² (AVAi); max PG 140 mmHg; mean PG 72 mmHg; mild–moderate AR/MR; mildly dilated ascending aorta (4.0 cm); trivial pericardial effusion.:contentReference[oaicite:0]{index=0}
+      'Bogle Gosford TTE 23.5.25.pdf', // Severe AS; AVA 0.81 cm² (AVAi); max PG 140 mmHg; mean PG 72 mmHg; mild–moderate AR/MR; mildly dilated ascending aorta (4.0 cm); trivial pericardial effusion.
     ],
     angio: [
-      'Bogle angio.pdf', // 23/07/2025 RNSH cath: mild non‑obstructive CAD; mild LAD/LCx/RCA disease; right‑dominant system; radial access.:contentReference[oaicite:1]{index=1}
+      'Bogle angio.pdf', // 23/07/2025 RNSH cath: mild non‑obstructive CAD; mild LAD/LCx/RCA disease; right‑dominant system; radial access.
     ],
     ecg: [
-      'Bogle ECG.pdf', // 12/06/2025: sinus rhythm; normal QRS (unconfirmed automated report visible on trace).:contentReference[oaicite:2]{index=2}
+      'Bogle ECG.pdf', // 12/06/2025: sinus rhythm; normal QRS (unconfirmed automated report visible on trace).
     ],
     ct: [
-      'Bogle CT TAVI.pdf', // 08/07/2025 PRP: mild aorto‑iliac tortuosity; aorto‑iliac atherosclerosis without high‑grade stenosis; 3‑vessel arch; vessel calibres adequate (e.g., R EIA 8×9 mm; L EIA 7×8 mm); 14‑mm opacity abutting mediastinum; consider PET; ?Sievers I bicuspid R/L calcified raphe.:contentReference[oaicite:3]{index=3}
+      'Bogle CT TAVI.pdf', // 08/07/2025 PRP: mild aorto‑iliac tortuosity; aorto‑iliac atherosclerosis without high‑grade stenosis; 3‑vessel arch; vessel calibres adequate (e.g., R EIA 8×9 mm; L EIA 7×8 mm); 14‑mm opacity abutting mediastinum; consider PET; ?Sievers I bicuspid R/L calcified raphe.
       'Norman bogle CT Tavi aortic root.pdf', // Additional CT aortic root measurements/images.
       'Norman bogle CT Tavi aortic root_1.pdf', // Additional CT aortic root measurements/images.
     ],
     oncology: [
-      'Bogle oncology letters april 25.pdf', // Collated cancer history; no recurrence/metastases on 02/04/2025 CT noted.:contentReference[oaicite:4]{index=4}
-      'Bogle oncology letters.pdf', // Medical oncology follow‑up: stable disease; notes literacy limitation (numbers/dates only) and social support from brother.:contentReference[oaicite:5]{index=5}
-      'Bogle oncology letters_1.pdf', // Radiation oncology/medical oncology letters: stable imaging; discharged from radiation oncology clinic; ongoing surveillance arrangements.:contentReference[oaicite:6]{index=6}
+      'Bogle oncology letters april 25.pdf', // Collated cancer history; no recurrence/metastases on 02/04/2025 CT noted.
+      'Bogle oncology letters.pdf', // Medical oncology follow‑up: stable disease; notes literacy limitation (numbers/dates only) and social support from brother.
     ],
     referral: [
-      'Bogle referral.pdf', // Coastal Cardiology letter (12/06/2025): severe AS (MG 72, AVA 0.8); bicuspid AV; CTCA Ca score 1272 with mild‑moderate CAD; TAVR referral to RNSH; started nebivolol 1.25 mg mane.:contentReference[oaicite:7]{index=7}
+      'Bogle referral.pdf', // Coastal Cardiology letter (12/06/2025): severe AS (MG 72, AVA 0.8); bicuspid AV; CTCA Ca score 1272 with mild‑moderate CAD; TAVR referral to RNSH; started nebivolol 1.25 mg mane.
     ],
     medtronic: [
-      'Bogle medtronic.pdf', // 3mensio/Evolut analysis: annulus mean Ø 24.1 mm (perimeter 75.8 mm; area‑derived Ø 23.7 mm); LVOT mean Ø 23.6 mm; STJ Ø 28.3 mm; SOV Ø ~35.7 mm; annular angulation ≈42°; ?Sievers I bicuspid.:contentReference[oaicite:8]{index=8}
+      'Bogle medtronic.pdf', // 3mensio/Evolut analysis: annulus mean Ø 24.1 mm (perimeter 75.8 mm; area‑derived Ø 23.7 mm); LVOT mean Ø 23.6 mm; STJ Ø 28.3 mm; SOV Ø ~35.7 mm; annular angulation ≈42°; ?Sievers I bicuspid.
     ],
   },
 
@@ -82,13 +81,13 @@ const patient: Patient = {
     AR: 'Mild–moderate',
     MR: 'Mild–moderate',
     Comments:
-      'Severe calcific AS with mild–moderate AR. Mildly dilated ascending aorta. Trivial pericardial effusion.:contentReference[oaicite:9]{index=9}',
+      'Severe calcific AS with mild–moderate AR. Mildly dilated ascending aorta. Trivial pericardial effusion.',
   },
 
-  angio: 'Mild non‑obstructive coronary artery disease — mild LAD/LCx/RCA disease; right‑dominant.:contentReference[oaicite:10]{index=10}',
-  ecg: 'Sinus rhythm with normal QRS complex.:contentReference[oaicite:11]{index=11}',
+  angio: 'Mild non‑obstructive coronary artery disease — mild LAD/LCx/RCA disease; right‑dominant.',
+  ecg: 'Sinus rhythm with normal QRS complex.',
   ctIncidentals:
-    '?Sievers Type I bicuspid with R/L Ca raphe. Aorto‑iliac atherosclerosis without high‑grade stenosis; mild tortuosity; 14‑mm mediastinal opacity near L inferior pulmonary vein (consider PET).:contentReference[oaicite:12]{index=12}',
+    '?Sievers Type I bicuspid with R/L Ca raphe. Aorto‑iliac atherosclerosis without high‑grade stenosis; mild tortuosity; 14‑mm mediastinal opacity near L inferior pulmonary vein (consider PET).',
 
   cognitive: {
     MOCA: 'Unable to read or write',
@@ -105,19 +104,19 @@ const patient: Patient = {
 
   investigationSummary: {
     tte:
-      '21/05/2025 (Gosford): Severe AS (AVA 0.81 cm²; max PG 140; mean 72) with mild–moderate AR/MR; EF >55%; mild–moderate LVH; mildly dilated ascending aorta (4.0 cm); trivial effusion.:contentReference[oaicite:13]{index=13}',
+      '21/05/2025 (Gosford): Severe AS (AVA 0.81 cm²; max PG 140; mean 72) with mild–moderate AR/MR; EF >55%; mild–moderate LVH; mildly dilated ascending aorta (4.0 cm); trivial effusion.',
     ct:
-      '08/07/2025 PRP CT‑TAVI: Access vessels adequate (e.g., R EIA 8×9 mm; L EIA 7×8 mm), mild tortuosity; aorto‑iliac atherosclerosis without high‑grade stenosis; 3‑vessel arch; incidental 14‑mm mediastinal opacity for PET consideration; suggests ?Sievers I bicuspid (R/L raphe).:contentReference[oaicite:14]{index=14}',
+      '08/07/2025 PRP CT‑TAVI: Access vessels adequate (e.g., R EIA 8×9 mm; L EIA 7×8 mm), mild tortuosity; aorto‑iliac atherosclerosis without high‑grade stenosis; 3‑vessel arch; incidental 14‑mm mediastinal opacity for PET consideration; suggests ?Sievers I bicuspid (R/L raphe).',
     angio:
-      '23/07/2025 RNSH cath: Mild non‑obstructive CAD (LAD/LCx/RCA mild disease); right dominant; radial access; proceed with AVR workup.:contentReference[oaicite:15]{index=15}',
+      '23/07/2025 RNSH cath: Mild non‑obstructive CAD (LAD/LCx/RCA mild disease); right dominant; radial access; proceed with AVR workup.',
     ecg:
-      '12/06/2025: Sinus rhythm, normal QRS; automated unconfirmed read on strip.:contentReference[oaicite:16]{index=16}',
+      '12/06/2025: Sinus rhythm, normal QRS; automated unconfirmed read on strip.',
     medtronic:
-      '3mensio/Evolut (reviewed 14/07/2025): Annulus mean Ø 24.1 mm (perimeter 75.8 mm); LVOT mean Ø 23.6 mm; STJ Ø 28.3 mm; SOV ≈35.7 mm; annular angulation ≈42°; ?Sievers I bicuspid; sizing grid provided.:contentReference[oaicite:17]{index=17}',
+      '3mensio/Evolut (reviewed 14/07/2025): Annulus mean Ø 24.1 mm (perimeter 75.8 mm); LVOT mean Ø 23.6 mm; STJ Ø 28.3 mm; SOV ≈35.7 mm; annular angulation ≈42°; ?Sievers I bicuspid; sizing grid provided.',
     consults: [
-      'Radiation Oncology — Dr Roland Yeghiaian‑Alvandi (26/02/2025): 4.5 years post‑chemoradiation for locally advanced NSCLC; most recent CT (Dec) stable; discharged from radiation oncology clinic; follow‑up as needed.:contentReference[oaicite:18]{index=18}',
-      'Medical Oncology — Dr Matthew Chan (09/04/2025 letter referenced; printed 30/06/2025): No evidence of recurrence or metastatic disease on 02/04/2025 CT; ongoing surveillance with Prof Michael Back; return if new symptoms; notes literacy limitation and family support.:contentReference[oaicite:19]{index=19}:contentReference[oaicite:20]{index=20}',
-      'Referring Cardiology — Dr Karthik Rangasamy (12/06/2025): Severe symptomatic AS (MG 72; AVA 0.8); bicuspid AV; CTCA Ca score 1272 with mild–moderate CAD; recommended TAVR over surgery; referred to RNSH (Dr Bhindi); started nebivolol 1.25 mg mane.:contentReference[oaicite:21]{index=21}',
+      'Radiation Oncology — Dr Roland Yeghiaian‑Alvandi (26/02/2025): 4.5 years post‑chemoradiation for locally advanced NSCLC; most recent CT (Dec) stable; discharged from radiation oncology clinic; follow‑up as needed.',
+      'Medical Oncology — Dr Matthew Chan (09/04/2025 letter referenced; printed 30/06/2025): No evidence of recurrence or metastatic disease on 02/04/2025 CT; ongoing surveillance with Prof Michael Back; return if new symptoms; notes literacy limitation and family support.',
+      'Referring Cardiology — Dr Karthik Rangasamy (12/06/2025): Severe symptomatic AS (MG 72; AVA 0.8); bicuspid AV; CTCA Ca score 1272 with mild–moderate CAD; recommended TAVR over surgery; referred to RNSH (Dr Bhindi); started nebivolol 1.25 mg mane.',
     ],
   },
 };

--- a/data/patients/smithm.ts
+++ b/data/patients/smithm.ts
@@ -19,23 +19,23 @@ const patient: Patient = {
       'Smith.M TTE RNSH 11.7.25.PDF', // 11/07/2025 RNSH: EF 55–60%; AVA 0.9 (AVAi 0.5); MG 33; PG 60; SVI 51.4; moderate AR; mild MR.
     ],
     angio: [
-      'Smith.M angio 2023.pdf', // 29/03/2023 NSTEMI work-up: normal coronaries; left-dominant; radial access; no complications. :contentReference[oaicite:0]{index=0}
+      'Smith.M angio 2023.pdf', // 29/03/2023 NSTEMI work-up: normal coronaries; left-dominant; radial access; no complications. 
     ],
     ecg: [
-      'Smith.M ECG.pdf', // 12‑lead strip uploaded (baseline). :contentReference[oaicite:1]{index=1}
+      'Smith.M ECG.pdf', // 12‑lead strip uploaded (baseline). 
     ],
     ct: [
-      'Smith.M CT TAVI.pdf', // PRP CT‑TAVI 13/05/2025: detailed annulus/coronary heights + access vessels; aorto‑iliac plaque/tortuosity; formal impression provided. :contentReference[oaicite:2]{index=2}
+      'Smith.M CT TAVI.pdf', // PRP CT‑TAVI 13/05/2025: detailed annulus/coronary heights + access vessels; aorto‑iliac plaque/tortuosity; formal impression provided. 
       'Smith.M medtronic.pdf',
     ],
     referral: [
-      'Smith.M referral.pdf', // 22/05/2025 Kull→Hansen: severe AS; porcelain aorta; on haemodialysis; consider TAVI at RNSH. :contentReference[oaicite:3]{index=3}
+      'Smith.M referral.pdf', // 22/05/2025 Kull→Hansen: severe AS; porcelain aorta; on haemodialysis; consider TAVI at RNSH. 
     ],
     medtronic: [
-      'Smith.M medtronic.pdf', // 3mensio/Evolut review 16/06/2025: L coronary slightly low (~9.8 mm); R SOV just undersized; annulus mean Ø 23.3; perimeter 72.5; STJ ~27; SOV ~29. :contentReference[oaicite:4]{index=4}
+      'Smith.M medtronic.pdf', // 3mensio/Evolut review 16/06/2025: L coronary slightly low (~9.8 mm); R SOV just undersized; annulus mean Ø 23.3; perimeter 72.5; STJ ~27; SOV ~29. 
     ],
     ctsx: [
-      'Smith.M Dr bassin.pdf', // 17/11/2023 Dr Levi Bassin (CTSx): porcelain aorta → open surgery prohibitive; manage medically unless more symptomatic; then consider high‑risk surgery or TAVI. :contentReference[oaicite:5]{index=5}
+      'Smith.M Dr bassin.pdf', // 17/11/2023 Dr Levi Bassin (CTSx): porcelain aorta → open surgery prohibitive; manage medically unless more symptomatic; then consider high‑risk surgery or TAVI. 
     ],
   },
 
@@ -83,7 +83,7 @@ const patient: Patient = {
   },
 
   angio:
-    'Normal coronary arteries; left‑dominant circulation; radial access; no complications (29/03/2023). :contentReference[oaicite:6]{index=6}',
+    'Normal coronary arteries; left‑dominant circulation; radial access; no complications (29/03/2023). ',
   ecg: 'Sinus rhythm with normal PR interval and QRS (per MDT).',
   ctIncidentals:
     'CT‑TAVI: annulus max 26 mm / min 21 mm; annulus area ~4.2 cm²; moderate valve calcification; trileaflet; RCA ostial height low (9.4–11.8 mm), LMCA 12.6–18 mm; aorto‑iliac plaque/tortuosity with femorals ~6–7 mm. Medtronic analysis notes L coronary slightly low (~9.8 mm) and R SOV just undersized. ',
@@ -105,16 +105,16 @@ const patient: Patient = {
     tte:
       '11/07/2025 (Choong review/Nasser report): EF 55–60%; severe AS physiology — MG 33, PG 60, AVA 0.9 (AVAi 0.5); SVI 51.4; AR moderate; MR mild; tri‑leaflet with moderate calcification; described overall as moderate–severe AS.',
     ct:
-      '13/05/2025 PRP CT‑TAVI: Annulus 26×21 mm (area ~4.2 cm²); moderate annular/subannular calcification (non‑protruding); tri‑leaflet morphology; RCA ostial height low (9.4–11.8 mm), LMCA 12.6–18 mm; aorto‑iliac plaque with mild–moderate tortuosity; CFAs ~6–7 mm. Impression: borderline small sinuses and low RCA height; access feasible but small. :contentReference[oaicite:8]{index=8}',
+      '13/05/2025 PRP CT‑TAVI: Annulus 26×21 mm (area ~4.2 cm²); moderate annular/subannular calcification (non‑protruding); tri‑leaflet morphology; RCA ostial height low (9.4–11.8 mm), LMCA 12.6–18 mm; aorto‑iliac plaque with mild–moderate tortuosity; CFAs ~6–7 mm. Impression: borderline small sinuses and low RCA height; access feasible but small. ',
     medtronic:
-      '3mensio/Evolut (reviewed 16/06/2025): Annulus mean Ø 23.3 mm (perimeter 72.5; area‑derived Ø 22.7); LVOT mean Ø 23.5; STJ ~27 mm; SOV ~28–29 mm; LCA height ~9.8 mm (slightly low); “R SOV just undersized”; annular angulation ≈48°. :contentReference[oaicite:9]{index=9}',
+      '3mensio/Evolut (reviewed 16/06/2025): Annulus mean Ø 23.3 mm (perimeter 72.5; area‑derived Ø 22.7); LVOT mean Ø 23.5; STJ ~27 mm; SOV ~28–29 mm; LCA height ~9.8 mm (slightly low); “R SOV just undersized”; annular angulation ≈48°. ',
     angio:
-      '29/03/2023 Gosford cath (ACS/NSTEMI work‑up): normal coronaries in a left‑dominant system; radial access; no complications; concluded “Normal coronary arteries.” Operators: Dr Andrew Hill et al. :contentReference[oaicite:10]{index=10}',
+      '29/03/2023 Gosford cath (ACS/NSTEMI work‑up): normal coronaries in a left‑dominant system; radial access; no complications; concluded “Normal coronary arteries.” Operators: Dr Andrew Hill et al. ',
     ecg:
-      'Uploaded resting 12‑lead strip; clinical summary used: SR with normal PR & QRS (per MDT). :contentReference[oaicite:11]{index=11}',
+      'Uploaded resting 12‑lead strip; clinical summary used: SR with normal PR & QRS (per MDT). ',
     consults: [
-      'Cardiothoracic Surgery — Dr Levi Bassin (17/11/2023): CT chest showed essentially porcelain aorta → open surgery prohibitive risk; symptoms well‑managed → recommend medical therapy; if symptoms worsen, consider very high‑risk surgery or TAVI. :contentReference[oaicite:12]{index=12}',
-      'Referring Interventional Cardiology — Dr Tony Kull (22/05/2025): Severe AS; on haemodialysis; porcelain aorta → surgery too risky; symptoms mild but history of APO ×3; request consideration for TAVI at RNSH. :contentReference[oaicite:13]{index=13}',
+      'Cardiothoracic Surgery — Dr Levi Bassin (17/11/2023): CT chest showed essentially porcelain aorta → open surgery prohibitive risk; symptoms well‑managed → recommend medical therapy; if symptoms worsen, consider very high‑risk surgery or TAVI. ',
+      'Referring Interventional Cardiology — Dr Tony Kull (22/05/2025): Severe AS; on haemodialysis; porcelain aorta → surgery too risky; symptoms mild but history of APO ×3; request consideration for TAVI at RNSH. ',
     ],
   },
 };

--- a/data/patients/washington.ts
+++ b/data/patients/washington.ts
@@ -9,25 +9,25 @@ const patient: Patient = {
     referring: 'Dr Malcolm Anastasius / Prof Peter Vale',
     consulting: 'Dr Peter Hansen',
     contact: '—',
-    weight: '47 kg',  // from TTE 15/07/2025 :contentReference[oaicite:0]{index=0}
-    height: '160 cm', // from TTE 15/07/2025 :contentReference[oaicite:1]{index=1}
+    weight: '47 kg',  // from TTE 15/07/2025 
+    height: '160 cm', // from TTE 15/07/2025 
     status: 'private',
     badges: ['MitraClip', 'TriClip'],
 
     pdfs: {
         tte: [
-            'Washington TTE.pdf', // 15/07/2025: EF ~65%; severe MR (anterior leaflet flail) with mean MV gradient 4 mmHg; severe TR (RVSP ~61 mmHg); moderate AS (AVA 1.1 cm²; PG/MG 31/16); mild–moderate AR; severely dilated atria. :contentReference[oaicite:2]{index=2}
+            'Washington TTE.pdf', // 15/07/2025: EF ~65%; severe MR (anterior leaflet flail) with mean MV gradient 4 mmHg; severe TR (RVSP ~61 mmHg); moderate AS (AVA 1.1 cm²; PG/MG 31/16); mild–moderate AR; severely dilated atria. 
         ],
         toe: [
-            'Washington TOE 22.7.25.pdf', // 22/07/2025 (Anastasius): Severe MR (EROA 0.55 cm²; RVol 61 mL) — A3 flail + P2 prolapse; moderate posterior MAC; MVA 4.4 cm²; suggested TEER strategy (1× NTW medial, 1× NT A2/P2). Severe secondary TR (EROA 0.36 cm²), type IIIb; max anteroseptal gap 4 mm; GLIDE 2. :contentReference[oaicite:3]{index=3}
+            'Washington TOE 22.7.25.pdf', // 22/07/2025 (Anastasius): Severe MR (EROA 0.55 cm²; RVol 61 mL) — A3 flail + P2 prolapse; moderate posterior MAC; MVA 4.4 cm²; suggested TEER strategy (1× NTW medial, 1× NT A2/P2). Severe secondary TR (EROA 0.36 cm²), type IIIb; max anteroseptal gap 4 mm; GLIDE 2. 
         ],
         rhc: [
-            'Washington RHC.pdf', // 24/07/2025 cath: RA mean ~10 (v 15), PA 55/16 (m 30), PCWP 24; CO ~3.1 L/min; PVR ~1.9 WU; mild, non‑obstructive CAD. :contentReference[oaicite:4]{index=4}
+            'Washington RHC.pdf', // 24/07/2025 cath: RA mean ~10 (v 15), PA 55/16 (m 30), PCWP 24; CO ~3.1 L/min; PVR ~1.9 WU; mild, non‑obstructive CAD. 
         ],
         consults: [
-            'Washington aged care.pdf', // Orthogeriatrics (Dr Carl Ward, 23/07/2025): RUDAS 26/30; independent in pADLs; no aged‑care contraindication to TriClip. :contentReference[oaicite:5]{index=5}
-            'Washington cardio consult 22.7.25.pdf', // Cardiology WR (Mowbray/Di Sano, 23/07/2025): severe MR/TR; recommend TriClip; arrange outpatient angiogram; aim discharge post geris review. :contentReference[oaicite:6]{index=6}
-            'Washington Dr Vale letters + TTE.pdf', // Prof Peter Vale letter (25/03/2024) + prior TTE: AF on apixaban (reduced dose), CCF, HTN, moderate MR/TR at that time; meds list and longitudinal context. :contentReference[oaicite:7]{index=7}
+            'Washington aged care.pdf', // Orthogeriatrics (Dr Carl Ward, 23/07/2025): RUDAS 26/30; independent in pADLs; no aged‑care contraindication to TriClip. 
+            'Washington cardio consult 22.7.25.pdf', // Cardiology WR (Mowbray/Di Sano, 23/07/2025): severe MR/TR; recommend TriClip; arrange outpatient angiogram; aim discharge post geris review. 
+            'Washington Dr Vale letters + TTE.pdf', // Prof Peter Vale letter (25/03/2024) + prior TTE: AF on apixaban (reduced dose), CCF, HTN, moderate MR/TR at that time; meds list and longitudinal context. 
         ],
     },
 
@@ -67,7 +67,7 @@ const patient: Patient = {
         AR: 'Mild–moderate',
         MR: 'Severe (posterior jet; anterior leaflet flail)',
         Comments:
-            'Normal LV size and systolic function; severely dilated LA/RA; severe MR and severe TR; moderate AS; no pericardial effusion. :contentReference[oaicite:8]{index=8}',
+            'Normal LV size and systolic function; severely dilated LA/RA; severe MR and severe TR; moderate AS; no pericardial effusion. ',
     },
 
     // TOE (22/07/2025) — key TEER metrics
@@ -81,14 +81,14 @@ const patient: Patient = {
         'Tricuspid type': 'IIIb; max anteroseptal gap 4 mm',
         'GLIDE score': '2',
         Notes:
-            'Challenging medial origin of MR with calcium shelf under P3; consider 1× NTW medially + 1× NT A2/P2. :contentReference[oaicite:9]{index=9}',
+            'Challenging medial origin of MR with calcium shelf under P3; consider 1× NTW medially + 1× NT A2/P2. ',
     },
 
-    angio: 'Mild, non‑obstructive coronary artery disease on coronary angiography. :contentReference[oaicite:10]{index=10}',
+    angio: 'Mild, non‑obstructive coronary artery disease on coronary angiography. ',
     ecg: 'Atrial fibrillation (baseline rhythm during admission).',
 
     cognitive: {
-        MOCA: '26/30', // RUDAS 26/30 documented by OT; functionally independent in pADLs. :contentReference[oaicite:11]{index=11}
+        MOCA: '26/30', // RUDAS 26/30 documented by OT; functionally independent in pADLs. 
     },
 
     bloods: {
@@ -102,15 +102,15 @@ const patient: Patient = {
 
     investigationSummary: {
         tte:
-            '15/07/2025: EF ~65%; severe MR (anterior leaflet flail), severe TR (RVSP ~61 mmHg); moderate AS (AVA 1.1 cm²; PG/MG 31/16); mild–moderate AR; severely dilated atria. :contentReference[oaicite:12]{index=12}',
+            '15/07/2025: EF ~65%; severe MR (anterior leaflet flail), severe TR (RVSP ~61 mmHg); moderate AS (AVA 1.1 cm²; PG/MG 31/16); mild–moderate AR; severely dilated atria. ',
         toe:
-            '22/07/2025 (Dr Malcolm Anastasius): Severe MR — EROA 0.55 cm², RVol 61 mL — A3 flail + P2 prolapse; MVA 4.4 cm²; recommend TEER strategy (1× NTW medial ± 1× NT A2/P2). Severe secondary TR — EROA 0.36 cm²; type IIIb; gap 4 mm; GLIDE 2. :contentReference[oaicite:13]{index=13}',
+            '22/07/2025 (Dr Malcolm Anastasius): Severe MR — EROA 0.55 cm², RVol 61 mL — A3 flail + P2 prolapse; MVA 4.4 cm²; recommend TEER strategy (1× NTW medial ± 1× NT A2/P2). Severe secondary TR — EROA 0.36 cm²; type IIIb; gap 4 mm; GLIDE 2. ',
         rhcLhc:
-            '24/07/2025 cath: RA mean ~10 (v 15); PA 55/16 (m 30); PCWP 24; CO ~3.1 L/min; PVR ~1.9 WU. Coronaries: mild non‑obstructive disease. :contentReference[oaicite:14]{index=14}',
+            '24/07/2025 cath: RA mean ~10 (v 15); PA 55/16 (m 30); PCWP 24; CO ~3.1 L/min; PVR ~1.9 WU. Coronaries: mild non‑obstructive disease. ',
         consults: [
-            'Orthogeriatrics — Dr Carl Ward (23/07/2025): RUDAS 26/30; mobile and self‑caring; **no aged‑care contraindication to TriClip**. :contentReference[oaicite:15]{index=15}',
-            'Cardiology Ward Round — Mowbray / Di Sano (23/07/2025): severe biventricular failure with severe MR/TR; **recommend TriClip**; plan discharge post geriatrics review; outpatient angiogram. :contentReference[oaicite:16]{index=16}',
-            'Referring Cardiology — Prof Peter Vale (25/03/2024): AF on reduced‑dose apixaban (weight <60 kg, age >80), HF, HTN; earlier echo with moderate MR/TR; continued conservative management at that time. :contentReference[oaicite:17]{index=17}',
+            'Orthogeriatrics — Dr Carl Ward (23/07/2025): RUDAS 26/30; mobile and self‑caring; **no aged‑care contraindication to TriClip**. ',
+            'Cardiology Ward Round — Mowbray / Di Sano (23/07/2025): severe biventricular failure with severe MR/TR; **recommend TriClip**; plan discharge post geriatrics review; outpatient angiogram. ',
+            'Referring Cardiology — Prof Peter Vale (25/03/2024): AF on reduced‑dose apixaban (weight <60 kg, age >80), HF, HTN; earlier echo with moderate MR/TR; continued conservative management at that time. ',
             'Feasibility Meeting (05/08/2025 — Hansen, Choong, Bromhead, Auton): TOE reviewed; small LV cavity; pathology at P2 and A3 flail. Options discussed: (1) single medial P1–P2 clip, or (2) two clips (2× Pascal or 2× NTW). *Per MDT notes.*',
         ],
     },


### PR DESCRIPTION
## Summary
- Clean up patient records by stripping `:contentReference` tags from PDF annotations and summaries.
- Drop an outdated oncology PDF entry from Bogle's record to ensure all referenced files exist.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899e3c420a48324876423422703deec