### PR TITLE
Show patient consults and link Medtronic CT PDFs

### DIFF
--- a/components/patient/ConsultsList.tsx
+++ b/components/patient/ConsultsList.tsx
@@ -1,0 +1,38 @@
+import { Typography } from 'antd';
+import PdfIcons from './PdfIcons';
+import type { Consults } from '../../data/patients/types';
+
+const { Text } = Typography;
+
+interface Props {
+  consults: Consults;
+}
+
+export default function ConsultsList({ consults }: Props) {
+  if (Array.isArray(consults)) {
+    return (
+      <>
+        {consults.map((c, idx) => (
+          <div key={idx} style={{ marginBottom: 8 }}>
+            <Text strong>
+              {c.date} {c.clinician}:
+            </Text>{' '}
+            {c.outcome}{' '}
+            <PdfIcons files={c.source} />
+          </div>
+        ))}
+      </>
+    );
+  }
+  return (
+    <>
+      {Object.entries(consults).map(([key, c]) => (
+        <div key={key} style={{ marginBottom: 8 }}>
+          <Text strong>{c.clinician}:</Text>{' '}
+          {c.recommendation}
+        </div>
+      ))}
+    </>
+  );
+}
+

--- a/components/patient/PatientPage.tsx
+++ b/components/patient/PatientPage.tsx
@@ -6,6 +6,8 @@ import PatientSection from './PatientSection';
 import PdfIcons from './PdfIcons';
 import { getAge } from '../../data/patients';
 import React from 'react';
+import ConsultsList from './ConsultsList';
+import type { Consults } from '../../data/patients/types';
 
 interface PatientRecord {
   id: string;
@@ -44,6 +46,7 @@ interface PatientRecord {
   agedCare?: string;
   agedCareNote?: string;
   consultTexts?: Record<string, string>;
+  consults?: Consults;
 }
 
 const { Text } = Typography;
@@ -68,6 +71,13 @@ export default function PatientPage({ patient }: { patient: PatientRecord }) {
     demographics.Weight = patient.weight ?? `${patient.weightKg} kg`;
   if (patient.height || patient.heightCm)
     demographics.Height = patient.height ?? `${patient.heightCm} cm`;
+
+  const ctPdfs = Array.from(
+    new Set([
+      ...(patient.pdfs?.ct ?? []),
+      ...(patient.pdfs?.medtronic ?? []),
+    ]),
+  );
 
   return (
     <PatientLayout title={patient.name}>
@@ -128,8 +138,8 @@ export default function PatientPage({ patient }: { patient: PatientRecord }) {
         </PatientSection>
       )}
 
-      {(patient.ctIncidentals || patient.pdfs?.ct) && (
-        <PatientSection title="CT TAVI / Access / Valve" pdfs={patient.pdfs?.ct}>
+      {(patient.ctIncidentals || ctPdfs.length) && (
+        <PatientSection title="CT TAVI / Access / Valve" pdfs={ctPdfs}>
           {patient.ctIncidentals && (
             <>
               <Text type="secondary">Incidentals:</Text>&nbsp;{patient.ctIncidentals}
@@ -171,6 +181,12 @@ export default function PatientPage({ patient }: { patient: PatientRecord }) {
       {patient.agedCareNote && (
         <PatientSection title="Aged Care Note" pdfs={patient.pdfs?.agedCareNote}>
           <Text>{patient.agedCareNote}</Text>
+        </PatientSection>
+      )}
+
+      {patient.consults && (
+        <PatientSection title="Consults">
+          <ConsultsList consults={patient.consults} />
         </PatientSection>
       )}
     </PatientLayout>

--- a/data/patients/gaffney.ts
+++ b/data/patients/gaffney.ts
@@ -75,8 +75,7 @@ const patient: Patient = {
 
   ecg: 'Sinus rhythm, first-degree PR; ventricular ectopics (per notes).',
 
-  ctIncidentals:
-    'No dedicated CT-TAVI PDF supplied. Medtronic planning report summarised below.',
+  ctIncidentals: 'Medtronic planning report summarised below.',
 
   cognitive: {
     MOCA: '27/30',


### PR DESCRIPTION
## Summary
- Render consult lists on patient pages
- Include Medtronic planning PDFs alongside CT TAVI documents
- Update Gaffney CT incidentals text to reference Medtronic planning

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a0c12b83c8324a2a08b7eede87acb